### PR TITLE
Fix/y valid without all classes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -21,7 +21,7 @@
 - Add a "model" that would aggregate several models (weak learners) into a meta model.
 - We should probably remove nb_iter_keras stuff. It is not used.
 - Review how the `get_classes_from_proba` and `inverse_transform` functions work! It is not very understandable!
-- Add used preprocessing as models' attributes.
+- Add used preprocessing as models' attributes ?
 - Remove / fix some `# type: ignore`.
 - Rework models folder hierarchy. We should add a directory per library (keras, sklearn, ...), and exploratory subdirectories.
 - Some 0_....py scripts are not tested (in functional tests).
@@ -35,6 +35,7 @@
 - Download flaubert_small_cased before using tests (in Actions)
 - Installation error with `python setup.py develop` when requirements.txt is not called first -> error: requests 2.28.0 is installed but requests<2.25.1,>=2.23.0 is required by {'words-n-fun'}
 - Shouldn't transformers be saved into `XXX-data` folder ? Like detectron models for the vision template ? (If changed, also change tutorial)
+- Add unit test model_pytorch
 
 
 ### Template - Numerical

--- a/gabarit/template_nlp/nlp_project/package_name/models_training/model_keras.py
+++ b/gabarit/template_nlp/nlp_project/package_name/models_training/model_keras.py
@@ -182,6 +182,13 @@ class ModelKeras(ModelClass):
             # Important : get_dummies reorder the columns in alphabetical order
             # Thus, there is no problem if we fit again on a new dataframe with shuffled data
             list_classes = list(y_train_dummies.columns)
+            # FIX: valid test might miss some classes, hence we need to add them back to y_valid_dummies
+            if y_valid_dummies is not None and y_train_dummies.shape[1] != y_valid_dummies.shape[1]:
+                for cl in list_classes:
+                    # Add missing columns
+                    if cl not in y_valid_dummies.columns:
+                        y_valid_dummies[cl] = 0
+                y_valid_dummies = y_valid_dummies[list_classes]  # Reorder
         # Else keep it as it is
         else:
             y_train_dummies = y_train

--- a/gabarit/template_nlp/nlp_project/package_name/models_training/model_pytorch.py
+++ b/gabarit/template_nlp/nlp_project/package_name/models_training/model_pytorch.py
@@ -156,6 +156,13 @@ class ModelPyTorch(ModelClass):
             # Important : get_dummies reorder the columns in alphabetical order
             # Thus, there is no problem if we fit again on a new dataframe with shuffled data
             list_classes = list(y_train_dummies.columns)
+            # FIX: valid test might miss some classes, hence we need to add them back to y_valid_dummies
+            if y_valid_dummies is not None and y_train_dummies.shape[1] != y_valid_dummies.shape[1]:
+                for cl in list_classes:
+                    # Add missing columns
+                    if cl not in y_valid_dummies.columns:
+                        y_valid_dummies[cl] = 0
+                y_valid_dummies = y_valid_dummies[list_classes]  # Reorder
         # Else keep it as it
         else:
             y_train_dummies = y_train

--- a/gabarit/template_num/num_project/package_name/models_training/model_keras.py
+++ b/gabarit/template_num/num_project/package_name/models_training/model_keras.py
@@ -182,6 +182,13 @@ class ModelKeras(ModelClass):
                 # Important : get_dummies reorder the columns in alphabetical order
                 # Thus, there is no problem if we fit again on a new dataframe with shuffled data
                 list_classes = list(y_train.columns)
+                # FIX: valid test might miss some classes, hence we need to add them back to y_valid
+                if y_valid is not None and y_train.shape[1] != y_valid.shape[1]:
+                    for cl in list_classes:
+                        # Add missing columns
+                        if cl not in y_valid.columns:
+                            y_valid[cl] = 0
+                    y_valid = y_valid[list_classes]  # Reorder
             # Else keep it as it is
             else:
                 y_train = y_train

--- a/gabarit/template_num/num_project/tests/test_model_keras.py
+++ b/gabarit/template_num/num_project/tests/test_model_keras.py
@@ -357,7 +357,7 @@ class ModelKerasTests(unittest.TestCase):
         model = ModelDenseClassifier(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False, keras_params={'learning_rate': lr, 'decay': 0.0})
         self.assertFalse(model.trained)
         self.assertEqual(model.nb_fit, 0)
-        model.fit(x_train, y_train_mono, x_valid=x_train, y_valid=y_valid_mono_missing, with_shuffle=True)
+        model.fit(x_train, y_train_mono_3, x_valid=x_train, y_valid=y_valid_mono_missing, with_shuffle=True)
         self.assertTrue(model.trained)
         self.assertEqual(model.nb_fit, 1)
         self.assertEqual(sorted(model.list_classes), [0, 1, 2])

--- a/gabarit/template_num/num_project/tests/test_model_keras.py
+++ b/gabarit/template_num/num_project/tests/test_model_keras.py
@@ -117,6 +117,8 @@ class ModelKerasTests(unittest.TestCase):
         x_train = pd.DataFrame({'col_1': [-5, -1, 0, -2, 2, -6, 3] * 10, 'col_2': [2, -1, -8, 2, 3, 12, 2] * 10})
         y_train_mono_2 = pd.Series([0, 0, 0, 0, 1, 1, 1] * 10)
         y_train_mono_3 = pd.Series([0, 0, 0, 2, 1, 1, 1] * 10)
+        y_valid_mono_missing = y_train_mono_3.copy()
+        y_valid_mono_missing[y_valid_mono_missing == 2] = 0
         y_train_regressor = pd.Series([-3, -2, -8, 0, 5, 6, 5] * 10)
         y_train_multi = pd.DataFrame({'y1': [0, 0, 0, 0, 1, 1, 1] * 10, 'y2': [1, 0, 0, 1, 1, 1, 1] * 10, 'y3': [0, 0, 1, 0, 1, 0, 1] * 10})
         x_col = ['col_1', 'col_2']
@@ -240,9 +242,6 @@ class ModelKerasTests(unittest.TestCase):
         remove_dir(model_dir)
 
 
-
-
-
         ## Classification - Mono-label - Multi-Classes
         model = ModelDenseClassifier(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False, keras_params={'learning_rate': lr, 'decay': 0.0})
         self.assertFalse(model.trained)
@@ -353,6 +352,18 @@ class ModelKerasTests(unittest.TestCase):
         y_train_mono_3_fake = pd.Series([5, 5, 8, 8, 2, 2, 2] * 10)
         with self.assertRaises(AssertionError):
             model.fit(x_train, y_train_mono_3_fake, x_valid=x_train, y_valid=y_train_mono_3, with_shuffle=False)
+        remove_dir(model_dir)
+        # Missing targets in y_valid
+        model = ModelDenseClassifier(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False, keras_params={'learning_rate': lr, 'decay': 0.0})
+        self.assertFalse(model.trained)
+        self.assertEqual(model.nb_fit, 0)
+        model.fit(x_train, y_train_mono, x_valid=x_train, y_valid=y_valid_mono_missing, with_shuffle=True)
+        self.assertTrue(model.trained)
+        self.assertEqual(model.nb_fit, 1)
+        self.assertEqual(sorted(model.list_classes), [0, 1, 2])
+        self.assertTrue(model.model._is_compiled)
+        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best.hdf5')))
+        self.assertEqual(lr, round(float(model.model.optimizer._decayed_lr(tensorflow.float32).numpy()), 6))
         remove_dir(model_dir)
 
 

--- a/gabarit/template_vision/vision_project/tests/test_model_keras.py
+++ b/gabarit/template_vision/vision_project/tests/test_model_keras.py
@@ -156,6 +156,8 @@ class ModelKerasTests(unittest.TestCase):
             'file_class': ['birman', 'birman', 'birman', 'bombay', 'bombay', 'bombay', 'shiba', 'shiba', 'shiba', 'shiba', 'birman', 'bombay'],
             'file_path': [os.path.join(data_path, _) for _ in filenames],
         })
+        df_valid_multi_missing = df_train_multi.copy()
+        df_valid_multi_missing['file_class'] = df_valid_multi_missing['file_class'].apply(lambda x: 'birman' if x == 'shiba' else x)
         # For the "val" datasets, we reuse the train, not important here
         fit_arguments_keys = ['x', 'y', 'batch_size', 'steps_per_epoch', 'validation_data', 'validation_split', 'validation_steps']  # wanted keys in fit_arguments
 
@@ -574,6 +576,28 @@ class ModelKerasTests(unittest.TestCase):
         })
         with self.assertRaises(AssertionError):
             fit_arguments = model.fit(df_train_multi_fake, df_valid=df_train_multi, with_shuffle=True)
+        remove_dir(model_dir)
+        # Missing targets in df_valid
+        model = ModelCnnClassifier(model_dir=model_dir, batch_size=2, epochs=2, keras_params={'learning_rate': lr, 'decay': 0.0})
+        self.assertFalse(model.trained)
+        self.assertEqual(model.nb_fit, 0)
+        fit_arguments = model.fit(df_train_multi, df_valid=df_valid_multi_missing, with_shuffle=True)
+        self.assertTrue(model.trained)
+        self.assertEqual(model.nb_fit, 1)
+        self.assertEqual(sorted(model.list_classes), ['birman', 'bombay', 'shiba'])
+        self.assertTrue(model.model._is_compiled)
+        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best.hdf5')))
+        self.assertEqual(lr, round(float(model.model.optimizer._decayed_lr(tensorflow.float32).numpy()), 6))
+        self.assertEqual(type(fit_arguments), dict)
+        self.assertTrue(all([_ in fit_arguments.keys() for _ in fit_arguments_keys]))
+        self.assertTrue(all([_ in fit_arguments_keys for _ in fit_arguments.keys()]))
+        self.assertIsNone(fit_arguments['y'])
+        self.assertIsNone(fit_arguments['batch_size'])
+        self.assertIsNone(fit_arguments['validation_split'])
+        self.assertIsNotNone(fit_arguments['x'])
+        self.assertIsNotNone(fit_arguments['validation_data'])
+        self.assertIsNotNone(fit_arguments['steps_per_epoch'])
+        self.assertIsNotNone(fit_arguments['validation_steps'])
         remove_dir(model_dir)
 
     def test03_model_keras_predict(self):


### PR DESCRIPTION
# Description

Some models would crash on fit with validation data missing at least a possible taget class (e.g. bad shape).

## Type of change

Added a check on fit function. If there are missing classes in validation set, we add them and properly reorder the dataset.

## How Has This Been Tested?

Added new tests for corresponding models.