### PR TITLE
Gabarit (fix): tmp fix for scipy version

### DIFF
--- a/gabarit/template_num/num_project/requirements.txt
+++ b/gabarit/template_num/num_project/requirements.txt
@@ -5,6 +5,7 @@ pandas==1.3.5
 # Models
 tensorflow==2.6.2
 scikit_learn==0.24.2
+scipy<1.9  # Tmp fix. Scipy 1.9 removed linalg.pinv2 which is not compatible with scikit_learn 0.24.2
 lightgbm==2.3.0
 xgboost==1.4.2
 

--- a/gabarit/template_num/num_project/setup.py
+++ b/gabarit/template_num/num_project/setup.py
@@ -38,6 +38,7 @@ setup(
         'numpy==1.19.5',
         'pandas==1.3.5',
         'scikit_learn>=0.24.2,<0.25',
+        'scipy<1.9',  # Tmp fix. Scipy 1.9 removed linalg.pinv2 which is not compatible with scikit_learn 0.24.2
         'lightgbm>=2.3.0,<2.3.1',  # Check if we can upgrade
         'xgboost>=1.4.2,<1.4.3',
         'matplotlib>=3.0.3,<3.4',


### PR DESCRIPTION
## ✒️ Context

- What kind of change does this PR introduce ?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧱 Description of Changes

- Prevent installation of scipy 1.9 that is not compatible with our version of sklearn

  - [ ] This is a change for the NLP template
  - [x] This is a change for the NUM template
  - [ ] This is a change for the VISION template
  - [ ] This changes how templates are generated (i.e. a Jinja change)

## 🩺 Testing

  - [x] This change does not need new tests
  - [ ] Added/Updated unit tests
  - [ ] Added/Updated functionals tests (i.e. e2e)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the GNU AFFERO GENERAL PUBLIC LICENSE.
