### PR TITLE
Feature/26 remove all nb iter keras stuffs

### DIFF
--- a/gabarit/template_nlp/nlp_project/package_name-scripts/2_training.py
+++ b/gabarit/template_nlp/nlp_project/package_name-scripts/2_training.py
@@ -58,7 +58,7 @@ logger = logging.getLogger('{{package_name}}.2_training')
 
 
 def main(filename: str, x_col: Union[str, int], y_col: List[Union[str, int]], filename_valid: Union[str, None] = None,
-         min_rows: Union[int, None] = None, nb_iter_keras: int = 1, level_save: str = 'HIGH',
+         min_rows: Union[int, None] = None, level_save: str = 'HIGH',
          sep: str = '{{default_sep}}', encoding: str = '{{default_encoding}}',
          model: Union[Type[ModelClass], None] = None) -> None:
     '''Trains a model
@@ -73,7 +73,6 @@ def main(filename: str, x_col: Union[str, int], y_col: List[Union[str, int]], fi
         filename_valid (str): Name of the validation dataset (actually a path relative to {{package_name}}-data)
             If None, we do not use a validation dataset.
                 -> for keras models (i.e. Neural Networks), we'll use a portion of the training dataset as the validation.
-        nb_iter_keras (int): For Keras models, number of models to train to improve stability (default 1).
         level_save (str): Save level
             LOW: statistics + configurations + logger keras - /!\\ the model won't be reusable /!\\ -
             MEDIUM: LOW + hdf5 + pkl + plots
@@ -243,27 +242,27 @@ def main(filename: str, x_col: Union[str, int], y_col: List[Union[str, int]], fi
         # model = model_embedding_lstm.ModelEmbeddingLstm(x_col=x_col, y_col=y_col, level_save=level_save,
         #                                                 batch_size=64, epochs=99, patience=5,
         #                                                 max_sequence_length=200, max_words=100000,
-        #                                                 multi_label=multi_label, nb_iter_keras=nb_iter_keras)
+        #                                                 multi_label=multi_label)
         # model = model_embedding_lstm_attention.ModelEmbeddingLstmAttention(x_col=x_col, y_col=y_col, level_save=level_save,
         #                                                                    batch_size=64, epochs=99, patience=5,
         #                                                                    max_sequence_length=200, max_words=100000,
-        #                                                                    multi_label=multi_label, nb_iter_keras=nb_iter_keras)
+        #                                                                    multi_label=multi_label)
         # model = model_embedding_lstm_structured_attention.ModelEmbeddingLstmStructuredAttention(x_col=x_col, y_col=y_col, level_save=level_save,
         #                                                                                         batch_size=64, epochs=99, patience=5,
         #                                                                                         max_sequence_length=200, max_words=100000,
-        #                                                                                         multi_label=multi_label, nb_iter_keras=nb_iter_keras)
+        #                                                                                         multi_label=multi_label)
         # model = model_embedding_lstm_gru_gpu.ModelEmbeddingLstmGruGpu(x_col=x_col, y_col=y_col, level_save=level_save,
         #                                                               batch_size=64, epochs=99, patience=5,
         #                                                               max_sequence_length=60, max_words=100000,
-        #                                                               multi_label=multi_label, nb_iter_keras=nb_iter_keras)
+        #                                                               multi_label=multi_label)
         # model = model_embedding_cnn.ModelEmbeddingCnn(x_col=x_col, y_col=y_col, level_save=level_save,
         #                                               batch_size=64, epochs=99, patience=5,
         #                                               max_sequence_length=200, max_words=100000,
-        #                                               multi_label=multi_label, nb_iter_keras=nb_iter_keras)
+        #                                               multi_label=multi_label)
         # model = model_tfidf_dense.ModelTfidfDense(x_col=x_col, y_col=y_col, level_save=level_save,
         #                                           batch_size=64, epochs=99, patience=5,
         #                                           tfidf_params={'analyzer': 'word', 'ngram_range': (1, 2), 'min_df': 1, 'max_df': 0.25, 'max_features': 100000},
-        #                                           multi_label=multi_label, nb_iter_keras=nb_iter_keras)
+        #                                           multi_label=multi_label)
         # model = model_pytorch_transformers.ModelPyTorchTransformers(x_col=x_col, y_col=y_col, level_save=level_save,
         #                                                             batch_size=64, epochs=10, patience=5,
         #                                                             transformer_name='flaubert/flaubert_base_cased',
@@ -391,7 +390,6 @@ if __name__ == '__main__':
     parser.add_argument('-y', '--y_col', nargs='+', required=True, help="Name of the model's target column(s) - y")
     parser.add_argument('-m', '--min_rows', type=int, default=None, help="Minimal number of occurrences for a class to be considered by the model")
     parser.add_argument('--filename_valid', default=None, help="Name of the validation dataset (actually a path relative to {{package_name}}-data)")
-    parser.add_argument('-i', '--nb_iter_keras', type=int, default=1, help="For Keras models, number of models to train to increase stability")
     parser.add_argument('-l', '--level_save', default='HIGH', help="Save level -> ['LOW', 'MEDIUM', 'HIGH']")
     parser.add_argument('--sep', default='{{default_sep}}', help="Separator to use with the .csv files.")
     parser.add_argument('--encoding', default="{{default_encoding}}", help="Encoding to use with the .csv files.")
@@ -407,5 +405,4 @@ if __name__ == '__main__':
     # Main
     main(filename=args.filename, x_col=args.x_col, y_col=args.y_col,
          min_rows=args.min_rows, filename_valid=args.filename_valid,
-         nb_iter_keras=args.nb_iter_keras, level_save=args.level_save,
-         sep=args.sep, encoding=args.encoding)
+         level_save=args.level_save, sep=args.sep, encoding=args.encoding)

--- a/gabarit/template_nlp/nlp_project/package_name/models_training/model_embedding_cnn.py
+++ b/gabarit/template_nlp/nlp_project/package_name/models_training/model_embedding_cnn.py
@@ -87,7 +87,7 @@ class ModelEmbeddingCnn(ModelKeras):
     def predict_proba(self, x_test, experimental_version: bool = False, **kwargs) -> np.ndarray:
         '''Predicts probabilities on the test dataset
 
-        Warning, this provides probabilities for a single model. If we use nb_iter > 1, we must use predict(return_proba=True)
+        Warning, this provides probabilities for a single model.
 
         Args:
             x_test (?): Array-like or sparse matrix, shape = [n_samples, n_features]
@@ -284,7 +284,7 @@ class ModelEmbeddingCnn(ModelKeras):
         for attribute in ['x_col', 'y_col',
                           'list_classes', 'dict_classes', 'multi_label', 'level_save',
                           'batch_size', 'epochs', 'validation_split', 'patience',
-                          'nb_iter_keras', 'keras_params', 'embedding_name', 'max_sequence_length',
+                          'keras_params', 'embedding_name', 'max_sequence_length',
                           'max_words', 'padding', 'truncating', 'tokenizer_filters']:
             setattr(self, attribute, configs.get(attribute, getattr(self, attribute)))
 

--- a/gabarit/template_nlp/nlp_project/package_name/models_training/model_embedding_lstm.py
+++ b/gabarit/template_nlp/nlp_project/package_name/models_training/model_embedding_lstm.py
@@ -89,7 +89,7 @@ class ModelEmbeddingLstm(ModelKeras):
     def predict_proba(self, x_test, experimental_version: bool = False, **kwargs) -> np.ndarray:
         '''Predicts probabilities on the test dataset
 
-        Warning, this provides probabilities for a single model. If we use nb_iter > 1, we must use predict(return_proba=True)
+        Warning, this provides probabilities for a single model.
 
         Args:
             x_test (?): Array-like or sparse matrix, shape = [n_samples, n_features]
@@ -273,7 +273,7 @@ class ModelEmbeddingLstm(ModelKeras):
         for attribute in ['x_col', 'y_col',
                           'list_classes', 'dict_classes', 'multi_label', 'level_save',
                           'batch_size', 'epochs', 'validation_split', 'patience',
-                          'nb_iter_keras', 'keras_params', 'embedding_name', 'max_sequence_length',
+                          'keras_params', 'embedding_name', 'max_sequence_length',
                           'max_words', 'padding', 'truncating', 'tokenizer_filters']:
             setattr(self, attribute, configs.get(attribute, getattr(self, attribute)))
 

--- a/gabarit/template_nlp/nlp_project/package_name/models_training/model_embedding_lstm_attention.py
+++ b/gabarit/template_nlp/nlp_project/package_name/models_training/model_embedding_lstm_attention.py
@@ -94,7 +94,7 @@ class ModelEmbeddingLstmAttention(ModelKeras):
     def predict_proba(self, x_test, experimental_version: bool = False, **kwargs) -> np.ndarray:
         '''Predicts probabilities on the test dataset
 
-        Warning, this provides probabilities for a single model. If we use nb_iter > 1, we must use predict(return_proba=True)
+        Warning, this provides probabilities for a single model.
 
         Args:
             x_test (?): Array-like or sparse matrix, shape = [n_samples, n_features]
@@ -110,7 +110,7 @@ class ModelEmbeddingLstmAttention(ModelKeras):
             return self.experimental_predict_proba(x_test)
         else:
             return self.model.predict(x_test, batch_size=128, verbose=1)  # type: ignore
-        
+
     def _prepare_x_train(self, x_train) -> np.ndarray:
         '''Prepares the input data for the model. Called when fitting the model
 
@@ -289,7 +289,7 @@ class ModelEmbeddingLstmAttention(ModelKeras):
         for attribute in ['x_col', 'y_col', 'list_classes', 'dict_classes', 'multi_label', 'level_save',
                           'batch_size', 'epochs', 'validation_split', 'patience',
                           'embedding_name', 'max_sequence_length', 'max_words', 'padding',
-                          'truncating', 'tokenizer_filters', 'nb_iter_keras', 'keras_params']:
+                          'truncating', 'tokenizer_filters', 'keras_params']:
             setattr(self, attribute, configs.get(attribute, getattr(self, attribute)))
 
         # Reload model

--- a/gabarit/template_nlp/nlp_project/package_name/models_training/model_embedding_lstm_gru_gpu.py
+++ b/gabarit/template_nlp/nlp_project/package_name/models_training/model_embedding_lstm_gru_gpu.py
@@ -91,7 +91,7 @@ class ModelEmbeddingLstmGruGpu(ModelKeras):
     def predict_proba(self, x_test, experimental_version: bool = False, **kwargs) -> np.ndarray:
         '''Predicts probabilities on the test dataset
 
-        Warning, this provides probabilities for a single model. If we use nb_iter > 1, we must use predict(return_proba=True)
+        Warning, this provides probabilities for a single model.
 
         Args:
             x_test (?): Array-like or sparse matrix, shape = [n_samples, n_features]
@@ -107,7 +107,7 @@ class ModelEmbeddingLstmGruGpu(ModelKeras):
             return self.experimental_predict_proba(x_test)
         else:
             return self.model.predict(x_test, batch_size=128, verbose=1)  # type: ignore
-       
+
 
     def _prepare_x_train(self, x_train) -> np.ndarray:
         '''Prepares the input data for the model. Called when fitting the model
@@ -293,7 +293,7 @@ class ModelEmbeddingLstmGruGpu(ModelKeras):
         for attribute in ['x_col', 'y_col',
                           'list_classes', 'dict_classes', 'multi_label', 'level_save',
                           'batch_size', 'epochs', 'validation_split', 'patience',
-                          'nb_iter_keras', 'keras_params', 'embedding_name', 'max_sequence_length',
+                          'keras_params', 'embedding_name', 'max_sequence_length',
                           'max_words', 'padding', 'truncating', 'tokenizer_filters']:
             setattr(self, attribute, configs.get(attribute, getattr(self, attribute)))
 

--- a/gabarit/template_nlp/nlp_project/package_name/models_training/model_embedding_lstm_structured_attention.py
+++ b/gabarit/template_nlp/nlp_project/package_name/models_training/model_embedding_lstm_structured_attention.py
@@ -99,7 +99,7 @@ class ModelEmbeddingLstmStructuredAttention(ModelKeras):
     def predict_proba(self, x_test, experimental_version: bool = False, **kwargs) -> np.ndarray:
         '''Predicts probabilities on the test dataset
 
-        Warning, this provides probabilities for a single model. If we use nb_iter > 1, we must use predict(return_proba=True)
+        Warning, this provides probabilities for a single model.
 
         Args:
             x_test (?): Array-like or sparse matrix, shape = [n_samples, n_features]
@@ -115,7 +115,7 @@ class ModelEmbeddingLstmStructuredAttention(ModelKeras):
             return self.experimental_predict_proba(x_test)
         else:
             return self.model.predict(x_test, batch_size=128, verbose=1)  # type: ignore
-       
+
 
     def _prepare_x_train(self, x_train) -> np.ndarray:
         '''Prepares the input data for the model. Called when fitting the model
@@ -398,7 +398,7 @@ class ModelEmbeddingLstmStructuredAttention(ModelKeras):
         for attribute in ['x_col', 'y_col', 'list_classes', 'dict_classes', 'multi_label', 'level_save',
                           'batch_size', 'epochs', 'validation_split', 'patience',
                           'embedding_name', 'max_sequence_length', 'max_words', 'padding',
-                          'truncating', 'oov_token', 'tokenizer_filters', 'nb_iter_keras', 'keras_params']:
+                          'truncating', 'oov_token', 'tokenizer_filters', 'keras_params']:
             setattr(self, attribute, configs.get(attribute, getattr(self, attribute)))
 
         # Reload model

--- a/gabarit/template_nlp/nlp_project/package_name/models_training/model_keras.py
+++ b/gabarit/template_nlp/nlp_project/package_name/models_training/model_keras.py
@@ -462,7 +462,7 @@ class ModelKeras(ModelClass):
                     filepath=os.path.join(self.model_dir, f'best.hdf5'), monitor='val_loss', save_best_only=True, mode='auto'
                 )
             )
-        callbacks.append(CSVLogger(filename=os.path.join(self.model_dir, f'logger{suff}.csv'), separator='{{default_sep}}', append=False))
+        callbacks.append(CSVLogger(filename=os.path.join(self.model_dir, f'logger.csv'), separator='{{default_sep}}', append=False))
         callbacks.append(TerminateOnNaN())
 
         # Get LearningRateScheduler

--- a/gabarit/template_nlp/nlp_project/package_name/models_training/model_keras.py
+++ b/gabarit/template_nlp/nlp_project/package_name/models_training/model_keras.py
@@ -62,7 +62,7 @@ class ModelKeras(ModelClass):
     # -> reload_from_standalone
 
     def __init__(self, batch_size: int = 64, epochs: int = 99, validation_split: float = 0.2, patience: int = 5,
-                 embedding_name: str = 'cc.fr.300.pkl', nb_iter_keras: int = 1, keras_params: Union[dict, None] = None, **kwargs) -> None:
+                 embedding_name: str = 'cc.fr.300.pkl', keras_params: Union[dict, None] = None, **kwargs) -> None:
         '''Initialization of the class (see ModelClass for more arguments)
 
         Kwargs:
@@ -72,10 +72,6 @@ class ModelKeras(ModelClass):
                 Only used if no input validation set when fitting
             patience (int): Early stopping patience
             embedding_name (str) : The name of the embedding matrix to use
-            nb_iter_keras (int): Number of iteration done when fitting (default: 1)
-                If != 1, one fits several times the same model (but with different initializations),
-                which gives a better stability
-                Can't fit again if > 1.
             keras_params (dict): Parameters used by keras models.
                 e.g. learning_rate, nb_lstm_units, etc...
                 The purpose of this dictionary is for the user to use it as they wants in the _get_model function
@@ -105,9 +101,6 @@ class ModelKeras(ModelClass):
         # Param embedding (can be None if no embedding)
         self.embedding_name = embedding_name
 
-        # Keras number of iteration
-        self.nb_iter_keras = nb_iter_keras
-
         # Keras params
         if keras_params is None:
             keras_params = {}
@@ -130,19 +123,15 @@ class ModelKeras(ModelClass):
                 This should be used if y is not shuffled as the split_validation takes the lines in order.
                 Thus, the validation set might get classes which are not in the train set ...
         Raises:
-            RuntimeError: If one tries to fit again a model with nb_iter_keras > 1
             AssertionError: If different classes when comparing an already fitted model and a new dataset
         '''
         ##############################################
         # Manage retrain
         ##############################################
 
-        if self.trained and self.nb_iter_keras > 1:
-            self.logger.error("We can't fit again a Keras model if nb_iter_keras > 1")
-            raise RuntimeError("We can't fit again a Keras model if nb_iter_keras > 1")
         # If a model has already been fitted, we make a new folder in order not to overwrite the existing one !
         # And we save the old conf
-        elif self.trained:
+        if self.trained:
             # Get src files to save
             src_files = [os.path.join(self.model_dir, "configurations.json")]
             if self.nb_fit > 1:
@@ -246,80 +235,73 @@ class ModelKeras(ModelClass):
         # Fit
         ##############################################
 
-        # Fit for each iteration wanted
-        for iter in range(self.nb_iter_keras):
-            if self.nb_iter_keras > 1:
-                self.logger.info(f"Training iteration {iter}")
+        # Get model (if already fitted we do not load a new one)
+        if not self.trained:
+            self.model = self._get_model()
 
-            # Get model (if already fitted we do not load a new one)
-            if not self.trained:
-                self.model = self._get_model()
+        # Get callbacks (early stopping & checkpoint)
+        callbacks = self._get_callbacks()
 
-            # Get callbacks (early stopping & checkpoint)
-            callbacks = self._get_callbacks(iter)
+        # Fit
+        # We use a try...except in order to save the model if an error arises
+        # after more than a minute into training
+        start_time = time.time()
+        try:
+            fit_history = self.model.fit(  # type: ignore
+                x_train,
+                y_train_dummies,
+                batch_size=self.batch_size,
+                epochs=self.epochs,
+                validation_split=self.validation_split if validation_data is None else None,
+                validation_data=validation_data,
+                callbacks=callbacks,
+                verbose=1,
+            )
+        except (RuntimeError, SystemError, SystemExit, EnvironmentError, KeyboardInterrupt, tf.errors.ResourceExhaustedError, tf.errors.InternalError,
+                tf.errors.UnavailableError, tf.errors.UnimplementedError, tf.errors.UnknownError, Exception) as e:
+            # Steps:
+            # 1. Display tensorflow error
+            # 2. Check if more than one minute elapsed & existence best.hdf5
+            # 3. Reload best model
+            # 4. We consider that a fit occured (trained = True, nb_fit += 1)
+            # 5. Save & create a warning file
+            # 6. Display error messages
+            # 7. Raise an error
 
-            # Fit
-            # We use a try...except in order to save the model if an error arises
-            # after more than a minute into training
-            start_time = time.time()
-            try:
-                fit_history = self.model.fit(  # type: ignore
-                    x_train,
-                    y_train_dummies,
-                    batch_size=self.batch_size,
-                    epochs=self.epochs,
-                    validation_split=self.validation_split if validation_data is None else None,
-                    validation_data=validation_data,
-                    callbacks=callbacks,
-                    verbose=1,
-                )
-            except (RuntimeError, SystemError, SystemExit, EnvironmentError, KeyboardInterrupt, tf.errors.ResourceExhaustedError, tf.errors.InternalError,
-                    tf.errors.UnavailableError, tf.errors.UnimplementedError, tf.errors.UnknownError, Exception) as e:
-                # Steps:
-                # 1. Display tensorflow error
-                # 2. Check if more than one minute elapsed & not several iterations & existence best.hdf5
-                # 3. Reload best model
-                # 4. We consider that a fit occured (trained = True, nb_fit += 1)
-                # 5. Save & create a warning file
-                # 6. Display error messages
-                # 7. Raise an error
+            # 1.
+            self.logger.error(repr(e))
 
-                # 1.
-                self.logger.error(repr(e))
+            # 2.
+            best_path = os.path.join(self.model_dir, 'best.hdf5')
+            time_spent = time.time() - start_time
+            if time_spent >= 60 and os.path.exists(best_path):
+                # 3.
+                self.model = load_model(best_path, custom_objects=self.custom_objects)
+                # 4.
+                self.trained = True
+                self.nb_fit += 1
+                # 5.
+                self.save()
+                with open(os.path.join(self.model_dir, "0_MODEL_INCOMPLETE"), 'w'):
+                    pass
+                with open(os.path.join(self.model_dir, "1_TRAINING_NEEDS_TO_BE_RESUMED"), 'w'):
+                    pass
+                # 6.
+                self.logger.error("[EXPERIMENTAL] Error during model training")
+                self.logger.error(f"[EXPERIMENTAL] The error happened after {round(time_spent, 2)}s of training")
+                self.logger.error("[EXPERIMENTAL] A saving of the model is done but this model won't be usable as is.")
+                self.logger.error(f"[EXPERIMENTAL] In order to resume the training, we have to specify this model ({ntpath.basename(self.model_dir)}) in the file 2_training.py")
+                self.logger.error("[EXPERIMENTAL] Warning, the preprocessing is not saved in the configuration file")
+                self.logger.error("[EXPERIMENTAL] Warning, the best model might be corrupted in some cases")
+            # 7.
+            raise RuntimeError("Error during model training")
 
-                # 2.
-                best_path = os.path.join(self.model_dir, 'best.hdf5')
-                time_spent = time.time() - start_time
-                if time_spent >= 60 and self.nb_iter_keras == 1 and os.path.exists(best_path):
-                    # 3.
-                    self.model = load_model(best_path, custom_objects=self.custom_objects)
-                    # 4.
-                    self.trained = True
-                    self.nb_fit += 1
-                    # 5.
-                    self.save()
-                    with open(os.path.join(self.model_dir, "0_MODEL_INCOMPLETE"), 'w'):
-                        pass
-                    with open(os.path.join(self.model_dir, "1_TRAINING_NEEDS_TO_BE_RESUMED"), 'w'):
-                        pass
-                    # 6.
-                    self.logger.error("[EXPERIMENTAL] Error during model training")
-                    self.logger.error(f"[EXPERIMENTAL] The error happened after {round(time_spent, 2)}s of training")
-                    self.logger.error("[EXPERIMENTAL] A saving of the model is done but this model won't be usable as is.")
-                    self.logger.error(f"[EXPERIMENTAL] In order to resume the training, we have to specify this model ({ntpath.basename(self.model_dir)}) in the file 2_training.py")
-                    self.logger.error("[EXPERIMENTAL] Warning, the preprocessing is not saved in the configuration file")
-                    self.logger.error("[EXPERIMENTAL] Warning, the best model might be corrupted in some cases")
-                # 7.
-                raise RuntimeError("Error during model training")
-
-            # Print accuracy & loss if level_save > 'LOW'
-            if self.level_save in ['MEDIUM', 'HIGH']:
-                self._plot_metrics_and_loss(fit_history, iter)
-                # Reload best model
-                self.model = load_model(
-                    os.path.join(self.model_dir, 'best.hdf5'),
-                    custom_objects=self.custom_objects
-                )
+        # Print accuracy & loss if level_save > 'LOW'
+        if self.level_save in ['MEDIUM', 'HIGH']:
+            # Plot accuracy
+            self._plot_metrics_and_loss(fit_history)
+            # Reload best model
+            self.model = load_model(os.path.join(self.model_dir, 'best.hdf5'), custom_objects=self.custom_objects)
 
         # Set trained
         self.trained = True
@@ -337,48 +319,12 @@ class ModelKeras(ModelClass):
         Returns:
             (np.ndarray): Array, shape = [n_samples, n_classes]
         '''
-        # Process
-        if self.nb_iter_keras <= 1:
-            with_iter = False
-        elif self.nb_iter_keras > 1 and self.level_save == 'LOW':
-            self.logger.warning("- *************** -")
-            self.logger.warning("Can't make a prediction with all iterations if level_save is LOW (no savings of the model).")
-            self.logger.warning("We only make prediction with the saved model.")
-            self.logger.warning("- *************** -")
-            with_iter = False
-        else:
-            with_iter = True
-
         # Cast in pd.Series
         x_test = pd.Series(x_test)
 
-        # Getting the available iterations
-        if with_iter:
-            list_file_hdf5 = [f for f in os.listdir(self.model_dir) if f.endswith('.hdf5')]
-            nb_iter_keras = len(list_file_hdf5)
-        else:
-            nb_iter_keras = 1
+        # Predict
+        predicted_proba = self.predict_proba(x_test)
 
-        predicted_proba = np.zeros((x_test.shape[0], len(self.list_classes)))  # type: ignore
-        for iter in range(nb_iter_keras):
-            # We get the model corresponding to the current iteration if there are more than one available model.
-            # Otherwise, we keep the model already set on the class (useful when save_level is LOW)
-            if nb_iter_keras > 1:
-                filename = 'best.hdf5' if iter == 0 else f'best_{iter}.hdf5'
-                self.logger.info(f"Predictions with file {filename}")
-                self.model = load_model(
-                    os.path.join(self.model_dir, f'{filename}'),
-                    custom_objects=self.custom_objects
-                )
-
-            # Get predictions per chunk
-            preds_iter = self.predict_proba(x_test)
-
-            # We sums the probabilities ...
-            predicted_proba = predicted_proba + preds_iter
-
-        # ... then we divide by the number of iterations in order to get a probability in [0, 1]
-        predicted_proba = predicted_proba / nb_iter_keras
         # We return the probabilities if wanted
         if return_proba:
             return predicted_proba
@@ -502,21 +448,18 @@ class ModelKeras(ModelClass):
         '''
         raise NotImplementedError("'_get_model' needs to be overridden")
 
-    def _get_callbacks(self, iter: int = 0) -> list:
+    def _get_callbacks(self) -> list:
         '''Gets model callbacks
 
-        Kwargs:
-            iter (int): Number of the current iteration, by default is 0
         Returns:
             list: List of callbacks
         '''
         # Get classic callbacks
         callbacks = [EarlyStopping(monitor='val_loss', patience=self.patience, restore_best_weights=True)]
-        suff = '' if iter == 0 else f'_{iter}'
         if self.level_save in ['MEDIUM', 'HIGH']:
             callbacks.append(
                 ModelCheckpoint(
-                    filepath=os.path.join(self.model_dir, f'best{suff}.hdf5'), monitor='val_loss', save_best_only=True, mode='auto'
+                    filepath=os.path.join(self.model_dir, f'best.hdf5'), monitor='val_loss', save_best_only=True, mode='auto'
                 )
             )
         callbacks.append(CSVLogger(filename=os.path.join(self.model_dir, f'logger{suff}.csv'), separator='{{default_sep}}', append=False))
@@ -533,7 +476,7 @@ class ModelKeras(ModelClass):
             models_path = utils.get_models_path()
             tensorboard_dir = os.path.join(models_path, 'tensorboard_logs')
             # We add a prefix so that the function load_model works correctly (it looks for a sub-folder with model name)
-            log_dir = os.path.join(tensorboard_dir, f"tensorboard_{ntpath.basename(self.model_dir)}_{iter}")
+            log_dir = os.path.join(tensorboard_dir, f"tensorboard_{ntpath.basename(self.model_dir)}")
             if not os.path.exists(log_dir):
                 os.makedirs(log_dir)
 
@@ -587,12 +530,11 @@ class ModelKeras(ModelClass):
         scheduler = None
         return scheduler
 
-    def _plot_metrics_and_loss(self, fit_history, iter: int) -> None:
+    def _plot_metrics_and_loss(self, fit_history) -> None:
         '''Plots accuracy & loss
 
         Arguments:
             fit_history (?) : fit history
-            iter (int): iteration en cours
         '''
         # Manage dir
         plots_path = os.path.join(self.model_dir, 'plots')
@@ -622,7 +564,7 @@ class ModelKeras(ModelClass):
                 plt.xlabel('Epoch')
                 plt.legend(['Train', 'Validation'], loc='upper left')
                 # Save
-                filename == f"{filename}.jpeg" if iter == 0 else f"{filename}_{iter}.jpeg"
+                filename == f"{filename}.jpeg"
                 plt.savefig(os.path.join(plots_path, filename))
 
                 # Close figures
@@ -660,7 +602,6 @@ class ModelKeras(ModelClass):
         json_data['validation_split'] = self.validation_split
         json_data['patience'] = self.patience
         json_data['embedding_name'] = self.embedding_name
-        json_data['nb_iter_keras'] = self.nb_iter_keras
         json_data['keras_params'] = self.keras_params
         if self.model is not None:
             json_data['keras_model'] = json.loads(self.model.to_json())

--- a/gabarit/template_nlp/nlp_project/package_name/models_training/model_tfidf_dense.py
+++ b/gabarit/template_nlp/nlp_project/package_name/models_training/model_tfidf_dense.py
@@ -244,7 +244,7 @@ class ModelTfidfDense(ModelKeras):
         for attribute in ['x_col', 'y_col',
                           'list_classes', 'dict_classes', 'multi_label', 'level_save',
                           'batch_size', 'epochs', 'validation_split', 'patience',
-                          'nb_iter_keras', 'keras_params', 'embedding_name']:
+                          'keras_params', 'embedding_name']:
             setattr(self, attribute, configs.get(attribute, getattr(self, attribute)))
 
         # Reload model

--- a/gabarit/template_nlp/nlp_project/tests/test_model_embedding_cnn.py
+++ b/gabarit/template_nlp/nlp_project/tests/test_model_embedding_cnn.py
@@ -178,18 +178,6 @@ class ModelEmbeddingCnnTests(unittest.TestCase):
         self.assertEqual([elem for elem in preds], [elem for elem in model.predict_proba(['test'], experimental_version=True)[0]])
         remove_dir(model_dir)
 
-        #
-        model = ModelEmbeddingCnn(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False,
-                                  max_sequence_length=10, max_words=100,
-                                  padding='pre', truncating='post',
-                                  embedding_name='fake_embedding.pkl', nb_iter_keras=3)
-        model.fit(x_train, y_train_mono)
-        preds = model.predict_proba(x_train)
-        self.assertEqual(preds.shape, (len(x_train), 3))
-        preds = model.predict_proba('test')
-        self.assertEqual([elem for elem in preds], [elem for elem in model.predict_proba(['test'])[0]])
-        remove_dir(model_dir)
-
         # Multi-labels
         model = ModelEmbeddingCnn(model_dir=model_dir, batch_size=8, epochs=2, multi_label=True,
                                   max_sequence_length=10, max_words=100,
@@ -212,18 +200,6 @@ class ModelEmbeddingCnnTests(unittest.TestCase):
         self.assertEqual(preds.shape, (len(x_train), len(cols)))
         preds = model.predict_proba('test', experimental_version=True)
         self.assertEqual([elem for elem in preds], [elem for elem in model.predict_proba(['test'], experimental_version=True)[0]])
-        remove_dir(model_dir)
-
-        #
-        model = ModelEmbeddingCnn(model_dir=model_dir, batch_size=8, epochs=2, multi_label=True,
-                                  max_sequence_length=10, max_words=100,
-                                  padding='pre', truncating='post',
-                                  embedding_name='fake_embedding.pkl', nb_iter_keras=3)
-        model.fit(x_train, y_train_multi[cols])
-        preds = model.predict_proba(x_train)
-        self.assertEqual(preds.shape, (len(x_train), len(cols)))
-        preds = model.predict_proba('test')
-        self.assertEqual([elem for elem in preds], [elem for elem in model.predict_proba(['test'])[0]])
         remove_dir(model_dir)
 
         # Model needs to be fitted

--- a/gabarit/template_nlp/nlp_project/tests/test_model_embedding_lstm.py
+++ b/gabarit/template_nlp/nlp_project/tests/test_model_embedding_lstm.py
@@ -177,18 +177,6 @@ class ModelEmbeddingLstmTests(unittest.TestCase):
         self.assertEqual([elem for elem in preds], [elem for elem in model.predict_proba(['test'], experimental_version=True)[0]])
         remove_dir(model_dir)
 
-        #
-        model = ModelEmbeddingLstm(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False,
-                                   max_sequence_length=10, max_words=100,
-                                   padding='pre', truncating='post',
-                                   embedding_name='fake_embedding.pkl', nb_iter_keras=3)
-        model.fit(x_train, y_train_mono)
-        preds = model.predict_proba(x_train)
-        self.assertEqual(preds.shape, (len(x_train), 3))
-        preds = model.predict_proba('test')
-        self.assertEqual([elem for elem in preds], [elem for elem in model.predict_proba(['test'])[0]])
-        remove_dir(model_dir)
-
         # Multi-labels
         model = ModelEmbeddingLstm(model_dir=model_dir, batch_size=8, epochs=2, multi_label=True,
                                    max_sequence_length=10, max_words=100,
@@ -211,18 +199,6 @@ class ModelEmbeddingLstmTests(unittest.TestCase):
         self.assertEqual(preds.shape, (len(x_train), len(cols)))
         preds = model.predict_proba('test', experimental_version=True)
         self.assertEqual([elem for elem in preds], [elem for elem in model.predict_proba(['test'], experimental_version=True)[0]])
-        remove_dir(model_dir)
-
-        #
-        model = ModelEmbeddingLstm(model_dir=model_dir, batch_size=8, epochs=2, multi_label=True,
-                                   max_sequence_length=10, max_words=100,
-                                   padding='pre', truncating='post',
-                                   embedding_name='fake_embedding.pkl', nb_iter_keras=3)
-        model.fit(x_train, y_train_multi[cols])
-        preds = model.predict_proba(x_train)
-        self.assertEqual(preds.shape, (len(x_train), len(cols)))
-        preds = model.predict_proba('test')
-        self.assertEqual([elem for elem in preds], [elem for elem in model.predict_proba(['test'])[0]])
         remove_dir(model_dir)
 
         # Model needs to be fitted

--- a/gabarit/template_nlp/nlp_project/tests/test_model_embedding_lstm_attention.py
+++ b/gabarit/template_nlp/nlp_project/tests/test_model_embedding_lstm_attention.py
@@ -177,18 +177,6 @@ class ModelEmbeddingLstmAttentionTests(unittest.TestCase):
         self.assertEqual([elem for elem in preds], [elem for elem in model.predict_proba(['test'], experimental_version=True)[0]])
         remove_dir(model_dir)
 
-        #
-        model = ModelEmbeddingLstmAttention(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False,
-                                            max_sequence_length=10, max_words=100,
-                                            padding='pre', truncating='post',
-                                            embedding_name='fake_embedding.pkl', nb_iter_keras=3)
-        model.fit(x_train, y_train_mono)
-        preds = model.predict_proba(x_train)
-        self.assertEqual(preds.shape, (len(x_train), 3))
-        preds = model.predict_proba('test')
-        self.assertEqual([elem for elem in preds], [elem for elem in model.predict_proba(['test'])[0]])
-        remove_dir(model_dir)
-
         # Multi-labels
         model = ModelEmbeddingLstmAttention(model_dir=model_dir, batch_size=8, epochs=2, multi_label=True,
                                             max_sequence_length=10, max_words=100,
@@ -211,18 +199,6 @@ class ModelEmbeddingLstmAttentionTests(unittest.TestCase):
         self.assertEqual(preds.shape, (len(x_train), len(cols)))
         preds = model.predict_proba('test', experimental_version=True)
         self.assertEqual([elem for elem in preds], [elem for elem in model.predict_proba(['test'], experimental_version=True)[0]])
-        remove_dir(model_dir)
-
-        #
-        model = ModelEmbeddingLstmAttention(model_dir=model_dir, batch_size=8, epochs=2, multi_label=True,
-                                            max_sequence_length=10, max_words=100,
-                                            padding='pre', truncating='post',
-                                            embedding_name='fake_embedding.pkl', nb_iter_keras=3)
-        model.fit(x_train, y_train_multi[cols])
-        preds = model.predict_proba(x_train)
-        self.assertEqual(preds.shape, (len(x_train), len(cols)))
-        preds = model.predict_proba('test')
-        self.assertEqual([elem for elem in preds], [elem for elem in model.predict_proba(['test'])[0]])
         remove_dir(model_dir)
 
         # Model needs to be fitted

--- a/gabarit/template_nlp/nlp_project/tests/test_model_embedding_lstm_gru_gpu.py
+++ b/gabarit/template_nlp/nlp_project/tests/test_model_embedding_lstm_gru_gpu.py
@@ -177,18 +177,6 @@ class ModelEmbeddingLstmGruGpuTests(unittest.TestCase):
         self.assertEqual([elem for elem in preds], [elem for elem in model.predict_proba(['test'], experimental_version=True)[0]])
         remove_dir(model_dir)
 
-        #
-        model = ModelEmbeddingLstmGruGpu(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False,
-                                         max_sequence_length=10, max_words=100,
-                                         padding='pre', truncating='post',
-                                         embedding_name='fake_embedding.pkl', nb_iter_keras=3)
-        model.fit(x_train, y_train_mono)
-        preds = model.predict_proba(x_train)
-        self.assertEqual(preds.shape, (len(x_train), 3))
-        preds = model.predict_proba('test')
-        self.assertEqual([elem for elem in preds], [elem for elem in model.predict_proba(['test'])[0]])
-        remove_dir(model_dir)
-
         # Multi-labels
         model = ModelEmbeddingLstmGruGpu(model_dir=model_dir, batch_size=8, epochs=2, multi_label=True,
                                          max_sequence_length=10, max_words=100,
@@ -211,18 +199,6 @@ class ModelEmbeddingLstmGruGpuTests(unittest.TestCase):
         self.assertEqual(preds.shape, (len(x_train), len(cols)))
         preds = model.predict_proba('test', experimental_version=True)
         self.assertEqual([elem for elem in preds], [elem for elem in model.predict_proba(['test'], experimental_version=True)[0]])
-        remove_dir(model_dir)
-
-        #
-        model = ModelEmbeddingLstmGruGpu(model_dir=model_dir, batch_size=8, epochs=2, multi_label=True,
-                                         max_sequence_length=10, max_words=100,
-                                         padding='pre', truncating='post',
-                                         embedding_name='fake_embedding.pkl', nb_iter_keras=3)
-        model.fit(x_train, y_train_multi[cols])
-        preds = model.predict_proba(x_train)
-        self.assertEqual(preds.shape, (len(x_train), len(cols)))
-        preds = model.predict_proba('test')
-        self.assertEqual([elem for elem in preds], [elem for elem in model.predict_proba(['test'])[0]])
         remove_dir(model_dir)
 
         # Model needs to be fitted

--- a/gabarit/template_nlp/nlp_project/tests/test_model_embedding_lstm_structured_attention.py
+++ b/gabarit/template_nlp/nlp_project/tests/test_model_embedding_lstm_structured_attention.py
@@ -194,18 +194,6 @@ class ModelEmbeddingLstmStructuredAttentionTests(unittest.TestCase):
         self.assertEqual([elem for elem in preds], [elem for elem in model.predict_proba(['test'], experimental_version=True)[0]])
         remove_dir(model_dir)
 
-        #
-        model = ModelEmbeddingLstmStructuredAttention(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False,
-                                                      max_sequence_length=10, max_words=100,
-                                                      padding='pre', truncating='post',
-                                                      embedding_name='fake_embedding.pkl', nb_iter_keras=3)
-        model.fit(x_train, y_train_mono)
-        preds = model.predict_proba(x_train)
-        self.assertEqual(preds.shape, (len(x_train), 3))
-        preds = model.predict_proba('test')
-        self.assertEqual([elem for elem in preds], [elem for elem in model.predict_proba(['test'])[0]])
-        remove_dir(model_dir)
-
         # Multi-labels
         model = ModelEmbeddingLstmStructuredAttention(model_dir=model_dir, batch_size=8, epochs=2, multi_label=True,
                                                       max_sequence_length=10, max_words=100,
@@ -228,18 +216,6 @@ class ModelEmbeddingLstmStructuredAttentionTests(unittest.TestCase):
         self.assertEqual(preds.shape, (len(x_train), len(cols)))
         preds = model.predict_proba('test', experimental_version=True)
         self.assertEqual([elem for elem in preds], [elem for elem in model.predict_proba(['test'], experimental_version=True)[0]])
-        remove_dir(model_dir)
-
-        #
-        model = ModelEmbeddingLstmStructuredAttention(model_dir=model_dir, batch_size=8, epochs=2, multi_label=True,
-                                                      max_sequence_length=10, max_words=100,
-                                                      padding='pre', truncating='post',
-                                                      embedding_name='fake_embedding.pkl', nb_iter_keras=3)
-        model.fit(x_train, y_train_multi[cols])
-        preds = model.predict_proba(x_train)
-        self.assertEqual(preds.shape, (len(x_train), len(cols)))
-        preds = model.predict_proba('test')
-        self.assertEqual([elem for elem in preds], [elem for elem in model.predict_proba(['test'])[0]])
         remove_dir(model_dir)
 
         # Model needs to be fitted

--- a/gabarit/template_nlp/nlp_project/tests/test_model_keras.py
+++ b/gabarit/template_nlp/nlp_project/tests/test_model_keras.py
@@ -119,11 +119,6 @@ class ModelKerasTests(unittest.TestCase):
         self.assertEqual(model.embedding_name, 'toto')
         remove_dir(model_dir)
 
-        #
-        model = ModelKeras(model_dir=model_dir, nb_iter_keras=2)
-        self.assertEqual(model.nb_iter_keras, 2)
-        remove_dir(model_dir)
-
         # keras_params must accept anything !
         model = ModelKeras(model_dir=model_dir, keras_params={'toto': 5})
         self.assertEqual(model.keras_params, {'toto': 5})
@@ -203,22 +198,6 @@ class ModelKerasTests(unittest.TestCase):
         self.assertEqual(sorted(model.list_classes), [0, 1, 2])
         self.assertTrue(model.model._is_compiled)
         self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best.hdf5')))
-        remove_dir(model_dir)
-
-        #
-        model = ModelEmbeddingLstm(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False,
-                                   max_sequence_length=10, max_words=100,
-                                   embedding_name='fake_embedding.pkl', nb_iter_keras=3)
-        self.assertFalse(model.trained)
-        self.assertEqual(model.nb_fit, 0)
-        model.fit(x_train, y_train_mono, x_valid=x_valid, y_valid=y_valid_mono, with_shuffle=True)
-        self.assertTrue(model.trained)
-        self.assertEqual(model.nb_fit, 1)
-        self.assertEqual(sorted(model.list_classes), [0, 1, 2])
-        self.assertTrue(model.model._is_compiled)
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best.hdf5')))
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best_1.hdf5')))
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best_2.hdf5')))
         remove_dir(model_dir)
 
         # Validation with y_train & y_valid of shape 2
@@ -307,22 +286,6 @@ class ModelKerasTests(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best.hdf5')))
         remove_dir(model_dir)
 
-        #
-        model = ModelEmbeddingLstm(model_dir=model_dir, batch_size=8, epochs=2, multi_label=True,
-                                   max_sequence_length=10, max_words=100,
-                                   embedding_name='fake_embedding.pkl', nb_iter_keras=3)
-        self.assertFalse(model.trained)
-        self.assertEqual(model.nb_fit, 0)
-        model.fit(x_train, y_train_multi, x_valid=x_valid, y_valid=y_valid_multi, with_shuffle=True)
-        self.assertTrue(model.trained)
-        self.assertEqual(model.nb_fit, 1)
-        self.assertEqual(sorted(model.list_classes), ['test1', 'test2', 'test3'])
-        self.assertTrue(model.model._is_compiled)
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best.hdf5')))
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best_1.hdf5')))
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best_2.hdf5')))
-        remove_dir(model_dir)
-
 
         ###########
         # Test continue training
@@ -376,24 +339,6 @@ class ModelKerasTests(unittest.TestCase):
         remove_dir(model_dir_2)
         remove_dir(model_dir_3)
         remove_dir(model_dir_4)
-
-        # Test iterations error mono-label
-        model = ModelEmbeddingLstm(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False,
-                                   max_sequence_length=10, max_words=100,
-                                   embedding_name='fake_embedding.pkl', nb_iter_keras=2)
-        self.assertFalse(model.trained)
-        self.assertEqual(model.nb_fit, 0)
-        model.fit(x_train, y_train_mono, x_valid=None, y_valid=None, with_shuffle=True)
-        model.save()
-        self.assertTrue(model.trained)
-        self.assertEqual(model.nb_fit, 1)
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best.hdf5')))
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'configurations.json')))
-        # Second fit
-        with self.assertRaises(RuntimeError):
-            model.fit(x_train[:50], y_train_mono[:50], x_valid=None, y_valid=None, with_shuffle=True)
-        self.assertEqual(model_dir, model.model_dir)
-        remove_dir(model_dir)
 
         # Test data errors mono-label
         model = ModelEmbeddingLstm(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False,
@@ -461,24 +406,6 @@ class ModelKerasTests(unittest.TestCase):
         remove_dir(model_dir_3)
         remove_dir(model_dir_4)
 
-        # Test iterations error multi-labels
-        model = ModelEmbeddingLstm(model_dir=model_dir, batch_size=8, epochs=2, multi_label=True,
-                                   max_sequence_length=10, max_words=100,
-                                   embedding_name='fake_embedding.pkl', nb_iter_keras=2)
-        self.assertFalse(model.trained)
-        self.assertEqual(model.nb_fit, 0)
-        model.fit(x_train, y_train_multi, x_valid=None, y_valid=None, with_shuffle=True)
-        model.save()
-        self.assertTrue(model.trained)
-        self.assertEqual(model.nb_fit, 1)
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best.hdf5')))
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'configurations.json')))
-        # Second fit
-        with self.assertRaises(RuntimeError):
-            model.fit(x_train[:50], y_train_multi[:50], x_valid=None, y_valid=None, with_shuffle=True)
-        self.assertEqual(model_dir, model.model_dir)
-        remove_dir(model_dir)
-
         # Test data errors multi-labels
         model = ModelEmbeddingLstm(model_dir=model_dir, batch_size=8, epochs=2, multi_label=True,
                                    max_sequence_length=10, max_words=100,
@@ -527,40 +454,10 @@ class ModelKerasTests(unittest.TestCase):
         self.assertEqual([elem for elem in proba], [elem for elem in model.predict(['test'], return_proba=True)[0]])
         remove_dir(model_dir)
 
-        #
-        model = ModelEmbeddingLstm(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False,
-                                   max_sequence_length=10, max_words=100,
-                                   embedding_name='fake_embedding.pkl', nb_iter_keras=3)
-        model.fit(x_train, y_train_mono)
-        preds = model.predict(x_train, return_proba=False)
-        self.assertEqual(preds.shape, (len(x_train),))
-        preds = model.predict('test', return_proba=False)
-        self.assertEqual(preds, model.predict(['test'], return_proba=False)[0])
-        proba = model.predict(x_train, return_proba=True)
-        self.assertEqual(proba.shape, (len(x_train), 3))
-        proba = model.predict('test', return_proba=True)
-        self.assertEqual([elem for elem in proba], [elem for elem in model.predict(['test'], return_proba=True)[0]])
-        remove_dir(model_dir)
-
         # Multi-labels
         model = ModelEmbeddingLstm(model_dir=model_dir, batch_size=8, epochs=2, multi_label=True,
                                    max_sequence_length=10, max_words=100,
                                    embedding_name='fake_embedding.pkl')
-        model.fit(x_train, y_train_multi)
-        preds = model.predict(x_train, return_proba=False)
-        self.assertEqual(preds.shape, (len(x_train), len(cols)))
-        preds = model.predict('test', return_proba=False)
-        self.assertEqual([elem for elem in preds], [elem for elem in model.predict(['test'], return_proba=False)[0]])
-        proba = model.predict(x_train, return_proba=True)
-        self.assertEqual(proba.shape, (len(x_train), len(cols)))
-        proba = model.predict('test', return_proba=True)
-        self.assertEqual([elem for elem in proba], [elem for elem in model.predict(['test'], return_proba=True)[0]])
-        remove_dir(model_dir)
-
-        #
-        model = ModelEmbeddingLstm(model_dir=model_dir, batch_size=8, epochs=2, multi_label=True,
-                                   max_sequence_length=10, max_words=100,
-                                   embedding_name='fake_embedding.pkl', nb_iter_keras=3)
         model.fit(x_train, y_train_multi)
         preds = model.predict(x_train, return_proba=False)
         self.assertEqual(preds.shape, (len(x_train), len(cols)))
@@ -756,7 +653,6 @@ class ModelKerasTests(unittest.TestCase):
         self.assertTrue('validation_split' in configs.keys())
         self.assertTrue('patience' in configs.keys())
         self.assertTrue('embedding_name' in configs.keys())
-        self.assertTrue('nb_iter_keras' in configs.keys())
         self.assertTrue('keras_params' in configs.keys())
         self.assertTrue('_get_model' in configs.keys())
         self.assertTrue('_get_learning_rate_scheduler' in configs.keys())
@@ -793,7 +689,6 @@ class ModelKerasTests(unittest.TestCase):
         self.assertTrue('validation_split' in configs.keys())
         self.assertTrue('patience' in configs.keys())
         self.assertTrue('embedding_name' in configs.keys())
-        self.assertTrue('nb_iter_keras' in configs.keys())
         self.assertTrue('keras_params' in configs.keys())
         self.assertTrue('_get_model' in configs.keys())
         self.assertTrue('_get_learning_rate_scheduler' in configs.keys())

--- a/gabarit/template_nlp/nlp_project/tests/test_model_keras.py
+++ b/gabarit/template_nlp/nlp_project/tests/test_model_keras.py
@@ -580,18 +580,6 @@ class ModelKerasTests(unittest.TestCase):
         self.assertEqual(checkpoint.filepath, os.path.join(model.model_dir, 'best.hdf5'))
         self.assertEqual(csv_logger.filename, os.path.join(model.model_dir, 'logger.csv'))
 
-        # iter > 0
-        callbacks = model._get_callbacks(2)
-        callbacks_types = [type(_) for _ in callbacks]
-        self.assertTrue(keras.callbacks.EarlyStopping in callbacks_types)
-        self.assertTrue(keras.callbacks.ModelCheckpoint in callbacks_types)
-        self.assertTrue(keras.callbacks.CSVLogger in callbacks_types)
-        self.assertTrue(keras.callbacks.TerminateOnNaN in callbacks_types)
-        checkpoint = callbacks[callbacks_types.index(keras.callbacks.ModelCheckpoint)]
-        csv_logger = callbacks[callbacks_types.index(keras.callbacks.CSVLogger)]
-        self.assertEqual(checkpoint.filepath, os.path.join(model.model_dir, 'best_2.hdf5'))
-        self.assertEqual(csv_logger.filename, os.path.join(model.model_dir, 'logger_2.csv'))
-
         # level save 'LOW'
         model.level_save = 'LOW'
         callbacks = model._get_callbacks()

--- a/gabarit/template_nlp/nlp_project/tests/test_model_tfidf_dense.py
+++ b/gabarit/template_nlp/nlp_project/tests/test_model_tfidf_dense.py
@@ -106,15 +106,6 @@ class ModelTfidfDenseTests(unittest.TestCase):
         self.assertEqual([elem for elem in preds], [elem for elem in model.predict_proba(['test'], experimental_version=True)[0]])
         remove_dir(model_dir)
 
-        #
-        model = ModelTfidfDense(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False, nb_iter_keras=3)
-        model.fit(x_train, y_train_mono)
-        preds = model.predict_proba(x_train)
-        self.assertEqual(preds.shape, (len(x_train), 3))
-        preds = model.predict_proba('test')
-        self.assertEqual([elem for elem in preds], [elem for elem in model.predict_proba(['test'])[0]])
-        remove_dir(model_dir)
-
         # Multi-labels
         model = ModelTfidfDense(model_dir=model_dir, batch_size=8, epochs=2, multi_label=True)
         model.fit(x_train, y_train_multi[cols])
@@ -131,15 +122,6 @@ class ModelTfidfDenseTests(unittest.TestCase):
         self.assertEqual(preds.shape, (len(x_train), len(cols)))
         preds = model.predict_proba('test', experimental_version=True)
         self.assertEqual([elem for elem in preds], [elem for elem in model.predict_proba(['test'], experimental_version=True)[0]])
-        remove_dir(model_dir)
-
-        #
-        model = ModelTfidfDense(model_dir=model_dir, batch_size=8, epochs=2, multi_label=True, nb_iter_keras=3)
-        model.fit(x_train, y_train_multi[cols])
-        preds = model.predict_proba(x_train)
-        self.assertEqual(preds.shape, (len(x_train), len(cols)))
-        preds = model.predict_proba('test')
-        self.assertEqual([elem for elem in preds], [elem for elem in model.predict_proba(['test'])[0]])
         remove_dir(model_dir)
 
         # Model needs to be fitted

--- a/gabarit/template_num/num_project/package_name-scripts/3_training_classification.py
+++ b/gabarit/template_num/num_project/package_name-scripts/3_training_classification.py
@@ -58,8 +58,8 @@ logger = logging.getLogger('{{package_name}}.3_training_classification')
 
 
 def main(filename: str, y_col: List[Union[str, int]], excluded_cols: Union[List[Union[str, int]], None] = None,
-         filename_valid: Union[str, None] = None, min_rows: Union[int, None] = None, nb_iter_keras: int = 1,
-         level_save: str = 'HIGH', sep: str = '{{default_sep}}', encoding: str = '{{default_encoding}}',
+         filename_valid: Union[str, None] = None, min_rows: Union[int, None] = None, level_save: str = 'HIGH',
+         sep: str = '{{default_sep}}', encoding: str = '{{default_encoding}}',
          model: Union[Type[ModelClass], None] = None) -> None:
     '''Trains a model
 
@@ -76,7 +76,6 @@ def main(filename: str, y_col: List[Union[str, int]], excluded_cols: Union[List[
         filename_valid (str): Name of the validation dataset (actually a path relative to {{package_name}}-data)
             If None, we do not use a validation dataset.
                 -> for keras models (i.e. Neural Networks), we'll use a portion of the training dataset as the validation.
-        nb_iter_keras (int): For Keras models, number of models to train to improve stability (default 1).
         level_save (str): Save level
             LOW: statistics + configurations + logger keras - /!\\ the model won't be reusable /!\\ -
             MEDIUM: LOW + hdf5 + pkl + plots
@@ -292,7 +291,7 @@ def main(filename: str, y_col: List[Union[str, int]], excluded_cols: Union[List[
         # model = model_dense_classifier.ModelDenseClassifier(x_col=x_col, y_col=y_col, level_save=level_save,
         #                                                     preprocess_pipeline=preprocess_pipeline,
         #                                                     batch_size=64, epochs=99, patience=5,
-        #                                                     multi_label=multi_label, nb_iter_keras=nb_iter_keras)
+        #                                                     multi_label=multi_label)
 
 
     # Display if GPU is being used
@@ -421,7 +420,6 @@ if __name__ == '__main__':
     parser.add_argument('--excluded_cols', nargs='+', default=None, help="List of columns NOT to use as model's input")
     parser.add_argument('-m', '--min_rows', type=int, default=None, help="Minimal number of occurrences for a class to be considered by the model")
     parser.add_argument('--filename_valid', default=None, help="Name of the validation dataset (actually a path relative to {{package_name}}-data)")
-    parser.add_argument('-i', '--nb_iter_keras', type=int, default=1, help="For Keras models, number of models to train to increase stability")
     parser.add_argument('-l', '--level_save', default='HIGH', help="Save level -> ['LOW', 'MEDIUM', 'HIGH']")
     parser.add_argument('--sep', default='{{default_sep}}', help="Separator to use with the .csv files.")
     parser.add_argument('--encoding', default="{{default_encoding}}", help="Encoding to use with the .csv files.")
@@ -437,5 +435,4 @@ if __name__ == '__main__':
     # Main
     main(filename=args.filename, y_col=args.y_col, excluded_cols=args.excluded_cols,
          min_rows=args.min_rows, filename_valid=args.filename_valid,
-         nb_iter_keras=args.nb_iter_keras, level_save=args.level_save,
-         sep=args.sep, encoding=args.encoding)
+         level_save=args.level_save, sep=args.sep, encoding=args.encoding)

--- a/gabarit/template_num/num_project/package_name-scripts/3_training_regression.py
+++ b/gabarit/template_num/num_project/package_name-scripts/3_training_regression.py
@@ -60,7 +60,7 @@ logger = logging.getLogger('{{package_name}}.3_training_regression')
 
 
 def main(filename: str, y_col: Union[str, int], excluded_cols: Union[List[Union[str, int]], None] = None,
-         filename_valid: Union[str, None] = None, nb_iter_keras: int = 1, level_save: str = 'HIGH',
+         filename_valid: Union[str, None] = None, level_save: str = 'HIGH',
          sep: str = '{{default_sep}}', encoding: str = '{{default_encoding}}',
          model: Union[Type[ModelClass], None] = None) -> None:
     '''Trains a model
@@ -76,7 +76,6 @@ def main(filename: str, y_col: Union[str, int], excluded_cols: Union[List[Union[
         filename_valid (str): Name of the validation dataset (actually a path relative to {{package_name}}-data)
             If None, we do not use a validation dataset.
                 -> for keras models (i.e. Neural Networks), we'll use a portion of the training dataset as the validation.
-        nb_iter_keras (int): For Keras models, number of models to train to improve stability (default 1).
         level_save (str): Save level
             LOW: statistics + configurations + logger keras - /!\\ the model won't be reusable /!\\ -
             MEDIUM: LOW + hdf5 + pkl + plots
@@ -225,8 +224,7 @@ def main(filename: str, y_col: Union[str, int], excluded_cols: Union[List[Union[
         #                                                              'learning_rate': 0.1, 'n_estimators': 100})
         # model = model_dense_regressor.ModelDenseRegressor(x_col=x_col, y_col=y_col, level_save=level_save,
         #                                                   preprocess_pipeline=preprocess_pipeline,
-        #                                                   batch_size=64, epochs=99, patience=5,
-        #                                                   nb_iter_keras=nb_iter_keras)
+        #                                                   batch_size=64, epochs=99, patience=5)
 
     # Display if GPU is being used
     model.display_if_gpu_activated()
@@ -351,7 +349,6 @@ if __name__ == '__main__':
     parser.add_argument('-y', '--y_col', required=True, help="Name of the model's target column - y")
     parser.add_argument('--excluded_cols', nargs='+', default=None, help="List of columns NOT to use as model's input")
     parser.add_argument('--filename_valid', default=None, help="Name of the validation dataset (actually a path relative to {{package_name}}-data)")
-    parser.add_argument('-i', '--nb_iter_keras', type=int, default=1, help="For Keras models, number of models to train to increase stability")
     parser.add_argument('-l', '--level_save', default='HIGH', help="Save level -> ['LOW', 'MEDIUM', 'HIGH']")
     parser.add_argument('--sep', default='{{default_sep}}', help="Separator to use with the .csv files.")
     parser.add_argument('--encoding', default="{{default_encoding}}", help="Encoding to use with the .csv files.")
@@ -366,5 +363,5 @@ if __name__ == '__main__':
         logger.info("----------------------------")
     # Main
     main(filename=args.filename, y_col=args.y_col, excluded_cols=args.excluded_cols,
-         filename_valid=args.filename_valid, nb_iter_keras=args.nb_iter_keras,
-         level_save=args.level_save, sep=args.sep, encoding=args.encoding)
+         filename_valid=args.filename_valid, level_save=args.level_save,
+         sep=args.sep, encoding=args.encoding)

--- a/gabarit/template_num/num_project/package_name/models_training/classifiers/model_dense_classifier.py
+++ b/gabarit/template_num/num_project/package_name/models_training/classifiers/model_dense_classifier.py
@@ -169,8 +169,7 @@ class ModelDenseClassifier(ModelClassifierMixin, ModelKeras):
         # Try to read the following attributes from configs and, if absent, keep the current one
         for attribute in ['model_type', 'x_col', 'y_col', 'columns_in', 'mandatory_columns',
                           'list_classes', 'dict_classes', 'multi_label', 'level_save',
-                          'batch_size', 'epochs', 'validation_split', 'patience',
-                          'nb_iter_keras', 'keras_params']:
+                          'batch_size', 'epochs', 'validation_split', 'patience', 'keras_params']:
             setattr(self, attribute, configs.get(attribute, getattr(self, attribute)))
 
         # Reload model

--- a/gabarit/template_num/num_project/package_name/models_training/regressors/model_dense_regressor.py
+++ b/gabarit/template_num/num_project/package_name/models_training/regressors/model_dense_regressor.py
@@ -149,7 +149,7 @@ class ModelDenseRegressor(ModelRegressorMixin, ModelKeras):
         # Try to read the following attributes from configs and, if absent, keep the current one
         for attribute in ['model_type', 'x_col', 'y_col', 'columns_in', 'mandatory_columns',
                           'level_save', 'batch_size', 'epochs', 'validation_split', 'patience',
-                          'nb_iter_keras', 'keras_params']:
+                          'keras_params']:
             setattr(self, attribute, configs.get(attribute, getattr(self, attribute)))
 
         # Reload model

--- a/gabarit/template_num/num_project/tests/test_model_dense_classifier.py
+++ b/gabarit/template_num/num_project/tests/test_model_dense_classifier.py
@@ -90,11 +90,6 @@ class ModelDenseClassifierTests(unittest.TestCase):
         self.assertEqual(model.patience, 65)
         remove_dir(model_dir)
 
-        #
-        model = ModelDenseClassifier(model_dir=model_dir, nb_iter_keras=2)
-        self.assertEqual(model.nb_iter_keras, 2)
-        remove_dir(model_dir)
-
         # keras_params must accept anything !
         model = ModelDenseClassifier(model_dir=model_dir, keras_params={'toto': 5})
         self.assertEqual(model.keras_params, {'toto': 5})
@@ -129,18 +124,6 @@ class ModelDenseClassifierTests(unittest.TestCase):
         proba = model.predict(x_train, return_proba=True, experimental_version=True)
         self.assertEqual(proba.shape, (len(x_train), 2)) # 2 classes
         remove_dir(model_dir)
-        # nb iter > 0
-        model = ModelDenseClassifier(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False, nb_iter_keras=3)
-        model.fit(x_train, y_train_mono_2)
-        preds = model.predict(x_train, return_proba=False)
-        self.assertEqual(preds.shape, (len(x_train),))
-        proba = model.predict(x_train, return_proba=True)
-        self.assertEqual(proba.shape, (len(x_train), 2)) # 2 classes
-        preds = model.predict(x_train, return_proba=False, experimental_version=True)
-        self.assertEqual(preds.shape, (len(x_train),))
-        proba = model.predict(x_train, return_proba=True, experimental_version=True)
-        self.assertEqual(proba.shape, (len(x_train), 2)) # 2 classes
-        remove_dir(model_dir)
 
         # Classification - Mono-label - Multi-Classes
         model = ModelDenseClassifier(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False)
@@ -154,33 +137,9 @@ class ModelDenseClassifierTests(unittest.TestCase):
         proba = model.predict(x_train, return_proba=True, experimental_version=True)
         self.assertEqual(proba.shape, (len(x_train), 3)) # 3 classes
         remove_dir(model_dir)
-        # nb iter > 0
-        model = ModelDenseClassifier(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False, nb_iter_keras=3)
-        model.fit(x_train, y_train_mono_3)
-        preds = model.predict(x_train, return_proba=False)
-        self.assertEqual(preds.shape, (len(x_train),))
-        proba = model.predict(x_train, return_proba=True)
-        self.assertEqual(proba.shape, (len(x_train), 3)) # 3 classes
-        preds = model.predict(x_train, return_proba=False, experimental_version=True)
-        self.assertEqual(preds.shape, (len(x_train),))
-        proba = model.predict(x_train, return_proba=True, experimental_version=True)
-        self.assertEqual(proba.shape, (len(x_train), 3)) # 3 classes
-        remove_dir(model_dir)
 
         # Classification - Multi-labels
         model = ModelDenseClassifier(model_dir=model_dir, batch_size=8, epochs=2, multi_label=True)
-        model.fit(x_train, y_train_multi)
-        preds = model.predict(x_train)
-        self.assertEqual(preds.shape, (len(x_train), len(y_col_multi)))
-        proba = model.predict(x_train, return_proba=True)
-        self.assertEqual(proba.shape, (len(x_train), len(y_col_multi)))
-        preds = model.predict(x_train, return_proba=False, experimental_version=True)
-        self.assertEqual(preds.shape, (len(x_train), len(y_col_multi)))
-        proba = model.predict(x_train, return_proba=True, experimental_version=True)
-        self.assertEqual(proba.shape, (len(x_train), len(y_col_multi)))
-        remove_dir(model_dir)
-        # nb iter > 0
-        model = ModelDenseClassifier(model_dir=model_dir, batch_size=8, epochs=2, multi_label=True, nb_iter_keras=3)
         model.fit(x_train, y_train_multi)
         preds = model.predict(x_train)
         self.assertEqual(preds.shape, (len(x_train), len(y_col_multi)))
@@ -361,7 +320,6 @@ class ModelDenseClassifierTests(unittest.TestCase):
         self.assertTrue('epochs' in configs.keys())
         self.assertTrue('validation_split' in configs.keys())
         self.assertTrue('patience' in configs.keys())
-        self.assertTrue('nb_iter_keras' in configs.keys())
         self.assertTrue('keras_params' in configs.keys())
         self.assertTrue('_get_model' in configs.keys())
         self.assertTrue('_get_learning_rate_scheduler' in configs.keys())
@@ -405,7 +363,6 @@ class ModelDenseClassifierTests(unittest.TestCase):
         self.assertTrue('epochs' in configs.keys())
         self.assertTrue('validation_split' in configs.keys())
         self.assertTrue('patience' in configs.keys())
-        self.assertTrue('nb_iter_keras' in configs.keys())
         self.assertTrue('keras_params' in configs.keys())
         self.assertTrue('_get_model' in configs.keys())
         self.assertTrue('_get_learning_rate_scheduler' in configs.keys())
@@ -524,7 +481,6 @@ class ModelDenseClassifierTests(unittest.TestCase):
         self.assertEqual(model.epochs, new_model.epochs)
         self.assertEqual(model.validation_split, new_model.validation_split)
         self.assertEqual(model.patience, new_model.patience)
-        self.assertEqual(model.nb_iter_keras, new_model.nb_iter_keras)
         self.assertEqual(model.keras_params, new_model.keras_params)
         self.assertEqual(model.custom_objects, new_model.custom_objects)
         self.assertTrue(new_model.preprocess_pipeline is not None)
@@ -565,7 +521,6 @@ class ModelDenseClassifierTests(unittest.TestCase):
         self.assertEqual(model.epochs, new_model.epochs)
         self.assertEqual(model.validation_split, new_model.validation_split)
         self.assertEqual(model.patience, new_model.patience)
-        self.assertEqual(model.nb_iter_keras, new_model.nb_iter_keras)
         self.assertEqual(model.keras_params, new_model.keras_params)
         self.assertEqual(model.custom_objects, new_model.custom_objects)
         self.assertTrue(new_model.preprocess_pipeline is not None)

--- a/gabarit/template_num/num_project/tests/test_model_dense_regressor.py
+++ b/gabarit/template_num/num_project/tests/test_model_dense_regressor.py
@@ -90,11 +90,6 @@ class ModelDenseRegressorTests(unittest.TestCase):
         self.assertEqual(model.patience, 65)
         remove_dir(model_dir)
 
-        #
-        model = ModelDenseRegressor(model_dir=model_dir, nb_iter_keras=2)
-        self.assertEqual(model.nb_iter_keras, 2)
-        remove_dir(model_dir)
-
         # keras_params must accept anything !
         model = ModelDenseRegressor(model_dir=model_dir, keras_params={'toto': 5})
         self.assertEqual(model.keras_params, {'toto': 5})
@@ -114,18 +109,6 @@ class ModelDenseRegressorTests(unittest.TestCase):
 
         # Regressor
         model = ModelDenseRegressor(x_col=x_col, y_col=y_col_mono, model_dir=model_dir, batch_size=8, epochs=2)
-        model.fit(x_train, y_train_regressor)
-        preds = model.predict(x_train, return_proba=False)
-        self.assertEqual(preds.shape, (len(x_train),))
-        with self.assertRaises(ValueError):
-            proba = model.predict(x_train, return_proba=True)
-        preds = model.predict(x_train, return_proba=False, experimental_version=True)
-        self.assertEqual(preds.shape, (len(x_train),))
-        with self.assertRaises(ValueError):
-            proba = model.predict(x_train, return_proba=True, experimental_version=True)
-        remove_dir(model_dir)
-        # nb iter > 0
-        model = ModelDenseRegressor(x_col=x_col, y_col=y_col_mono, model_dir=model_dir, batch_size=8, epochs=2, nb_iter_keras=3)
         model.fit(x_train, y_train_regressor)
         preds = model.predict(x_train, return_proba=False)
         self.assertEqual(preds.shape, (len(x_train),))
@@ -203,7 +186,6 @@ class ModelDenseRegressorTests(unittest.TestCase):
         self.assertTrue('epochs' in configs.keys())
         self.assertTrue('validation_split' in configs.keys())
         self.assertTrue('patience' in configs.keys())
-        self.assertTrue('nb_iter_keras' in configs.keys())
         self.assertTrue('keras_params' in configs.keys())
         self.assertTrue('_get_model' in configs.keys())
         self.assertTrue('_get_learning_rate_scheduler' in configs.keys())
@@ -244,7 +226,6 @@ class ModelDenseRegressorTests(unittest.TestCase):
         self.assertTrue('epochs' in configs.keys())
         self.assertTrue('validation_split' in configs.keys())
         self.assertTrue('patience' in configs.keys())
-        self.assertTrue('nb_iter_keras' in configs.keys())
         self.assertTrue('keras_params' in configs.keys())
         self.assertTrue('_get_model' in configs.keys())
         self.assertTrue('_get_learning_rate_scheduler' in configs.keys())
@@ -320,7 +301,6 @@ class ModelDenseRegressorTests(unittest.TestCase):
         self.assertEqual(model.epochs, new_model.epochs)
         self.assertEqual(model.validation_split, new_model.validation_split)
         self.assertEqual(model.patience, new_model.patience)
-        self.assertEqual(model.nb_iter_keras, new_model.nb_iter_keras)
         self.assertEqual(model.keras_params, new_model.keras_params)
         self.assertEqual(model.custom_objects, new_model.custom_objects)
         self.assertTrue(new_model.preprocess_pipeline is not None)

--- a/gabarit/template_num/num_project/tests/test_model_keras.py
+++ b/gabarit/template_num/num_project/tests/test_model_keras.py
@@ -95,11 +95,6 @@ class ModelKerasTests(unittest.TestCase):
         self.assertEqual(model.patience, 65)
         remove_dir(model_dir)
 
-        #
-        model = ModelKeras(model_dir=model_dir, nb_iter_keras=2)
-        self.assertEqual(model.nb_iter_keras, 2)
-        remove_dir(model_dir)
-
         # keras_params must accept anything !
         model = ModelKeras(model_dir=model_dir, keras_params={'toto': 5})
         self.assertEqual(model.keras_params, {'toto': 5})
@@ -162,19 +157,6 @@ class ModelKerasTests(unittest.TestCase):
         self.assertEqual(sorted(model.list_classes), [0, 1])
         self.assertTrue(model.model._is_compiled)
         self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best.hdf5')))
-        # With several iterations
-        model = ModelDenseClassifier(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False, nb_iter_keras=3)
-        self.assertFalse(model.trained)
-        self.assertEqual(model.nb_fit, 0)
-        self.assertEqual(model.nb_iter_keras, 3)
-        model.fit(x_train, y_train_mono_2, x_valid=x_train, y_valid=y_train_mono_2, with_shuffle=False)
-        self.assertTrue(model.trained)
-        self.assertEqual(model.nb_fit, 1)
-        self.assertEqual(sorted(model.list_classes), [0, 1])
-        self.assertTrue(model.model._is_compiled)
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best.hdf5')))
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best_1.hdf5')))
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best_2.hdf5')))
         # Wrong x_col
         with self.assertRaises(ValueError):
             model = ModelDenseClassifier(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False, x_col=['toto'])
@@ -212,20 +194,6 @@ class ModelKerasTests(unittest.TestCase):
         remove_dir(model_dir)
         remove_dir(model_dir_2)
         remove_dir(model_dir_3)
-        # Test iterations error
-        model = ModelDenseClassifier(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False, nb_iter_keras=2)
-        self.assertFalse(model.trained)
-        self.assertEqual(model.nb_fit, 0)
-        model.fit(x_train, y_train_mono_2, x_valid=x_train, y_valid=y_train_mono_2, with_shuffle=False)
-        model.save()
-        self.assertTrue(model.trained)
-        self.assertEqual(model.nb_fit, 1)
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best.hdf5')))
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'configurations.json')))
-        with self.assertRaises(RuntimeError):
-            model.fit(x_train, y_train_mono_2, x_valid=x_train, y_valid=y_train_mono_2, with_shuffle=False)
-        self.assertEqual(model_dir, model.model_dir)
-        remove_dir(model_dir)
         # Test data errors
         model = ModelDenseClassifier(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False)
         self.assertFalse(model.trained)
@@ -275,19 +243,6 @@ class ModelKerasTests(unittest.TestCase):
         self.assertEqual(sorted(model.list_classes), [0, 1, 2])
         self.assertTrue(model.model._is_compiled)
         self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best.hdf5')))
-        # With several iterations
-        model = ModelDenseClassifier(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False, nb_iter_keras=3)
-        self.assertFalse(model.trained)
-        self.assertEqual(model.nb_fit, 0)
-        self.assertEqual(model.nb_iter_keras, 3)
-        model.fit(x_train, y_train_mono_3, x_valid=x_train, y_valid=y_train_mono_3, with_shuffle=False)
-        self.assertTrue(model.trained)
-        self.assertEqual(model.nb_fit, 1)
-        self.assertEqual(sorted(model.list_classes), [0, 1, 2])
-        self.assertTrue(model.model._is_compiled)
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best.hdf5')))
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best_1.hdf5')))
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best_2.hdf5')))
         # Wrong x_col
         with self.assertRaises(ValueError):
             model = ModelDenseClassifier(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False, x_col=['toto'])
@@ -325,20 +280,6 @@ class ModelKerasTests(unittest.TestCase):
         remove_dir(model_dir)
         remove_dir(model_dir_2)
         remove_dir(model_dir_3)
-        # Test iterations error
-        model = ModelDenseClassifier(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False, nb_iter_keras=2)
-        self.assertFalse(model.trained)
-        self.assertEqual(model.nb_fit, 0)
-        model.fit(x_train, y_train_mono_3, x_valid=x_train, y_valid=y_train_mono_3, with_shuffle=False)
-        model.save()
-        self.assertTrue(model.trained)
-        self.assertEqual(model.nb_fit, 1)
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best.hdf5')))
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'configurations.json')))
-        with self.assertRaises(RuntimeError):
-            model.fit(x_train, y_train_mono_3, x_valid=x_train, y_valid=y_train_mono_3, with_shuffle=False)
-        self.assertEqual(model_dir, model.model_dir)
-        remove_dir(model_dir)
         # Test data errors
         model = ModelDenseClassifier(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False)
         self.assertFalse(model.trained)
@@ -403,20 +344,6 @@ class ModelKerasTests(unittest.TestCase):
         self.assertEqual(sorted(model.list_classes), y_col_multi)
         self.assertTrue(model.model._is_compiled)
         self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best.hdf5')))
-        # With several iterations
-        model = ModelDenseClassifier(model_dir=model_dir, batch_size=8, epochs=2, multi_label=True, nb_iter_keras=3)
-        self.assertFalse(model.trained)
-        self.assertEqual(model.nb_fit, 0)
-        self.assertTrue(model.multi_label)
-        self.assertEqual(model.nb_iter_keras, 3)
-        model.fit(x_train, y_train_multi, x_valid=x_train, y_valid=y_train_multi, with_shuffle=False)
-        self.assertTrue(model.trained)
-        self.assertEqual(model.nb_fit, 1)
-        self.assertEqual(sorted(model.list_classes), y_col_multi)
-        self.assertTrue(model.model._is_compiled)
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best.hdf5')))
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best_1.hdf5')))
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best_2.hdf5')))
         # Wrong x_col
         with self.assertRaises(ValueError):
             model = ModelDenseClassifier(model_dir=model_dir, batch_size=8, epochs=2, multi_label=True, x_col=['toto'])
@@ -454,21 +381,6 @@ class ModelKerasTests(unittest.TestCase):
         remove_dir(model_dir)
         remove_dir(model_dir_2)
         remove_dir(model_dir_3)
-        # Test iterations error
-        model = ModelDenseClassifier(model_dir=model_dir, batch_size=8, epochs=2, multi_label=True, nb_iter_keras=2)
-        self.assertFalse(model.trained)
-        self.assertEqual(model.nb_fit, 0)
-        model.fit(x_train, y_train_multi, x_valid=x_train, y_valid=y_train_multi, with_shuffle=False)
-        model.save()
-        self.assertTrue(model.trained)
-        self.assertEqual(model.nb_fit, 1)
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best.hdf5')))
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'configurations.json')))
-        with self.assertRaises(RuntimeError):
-            model.fit(x_train, y_train_multi, x_valid=x_train, y_valid=y_train_multi, with_shuffle=False)
-        self.assertEqual(model_dir, model.model_dir)
-        remove_dir(model_dir)
-
 
         ## Regression
         model = ModelDenseRegressor(model_dir=model_dir, batch_size=8, epochs=2, keras_params={'learning_rate': lr, 'decay': 0.0})
@@ -500,18 +412,6 @@ class ModelKerasTests(unittest.TestCase):
         self.assertEqual(model.nb_fit, 1)
         self.assertTrue(model.model._is_compiled)
         self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best.hdf5')))
-        # With several iterations
-        model = ModelDenseRegressor(model_dir=model_dir, batch_size=8, epochs=2, nb_iter_keras=3)
-        self.assertFalse(model.trained)
-        self.assertEqual(model.nb_fit, 0)
-        self.assertEqual(model.nb_iter_keras, 3)
-        model.fit(x_train, y_train_regressor, x_valid=x_train, y_valid=y_train_regressor, with_shuffle=False)
-        self.assertTrue(model.trained)
-        self.assertEqual(model.nb_fit, 1)
-        self.assertTrue(model.model._is_compiled)
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best.hdf5')))
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best_1.hdf5')))
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best_2.hdf5')))
         # Wrong x_col
         with self.assertRaises(ValueError):
             model = ModelDenseRegressor(model_dir=model_dir, batch_size=8, epochs=2, x_col=['toto'])
@@ -549,20 +449,6 @@ class ModelKerasTests(unittest.TestCase):
         remove_dir(model_dir)
         remove_dir(model_dir_2)
         remove_dir(model_dir_3)
-        # Test iterations error
-        model = ModelDenseRegressor(model_dir=model_dir, batch_size=8, epochs=2, nb_iter_keras=2)
-        self.assertFalse(model.trained)
-        self.assertEqual(model.nb_fit, 0)
-        model.fit(x_train, y_train_regressor, x_valid=x_train, y_valid=y_train_regressor, with_shuffle=False)
-        model.save()
-        self.assertTrue(model.trained)
-        self.assertEqual(model.nb_fit, 1)
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'best.hdf5')))
-        self.assertTrue(os.path.exists(os.path.join(model.model_dir, 'configurations.json')))
-        with self.assertRaises(RuntimeError):
-            model.fit(x_train, y_train_regressor, x_valid=x_train, y_valid=y_train_regressor, with_shuffle=False)
-        self.assertEqual(model_dir, model.model_dir)
-        remove_dir(model_dir)
 
 
     def test03_model_keras_predict(self):
@@ -593,33 +479,9 @@ class ModelKerasTests(unittest.TestCase):
         proba = model.predict(x_train, return_proba=True, experimental_version=True)
         self.assertEqual(proba.shape, (len(x_train), 2)) # 2 classes
         remove_dir(model_dir)
-        # nb iter > 0
-        model = ModelDenseClassifier(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False, nb_iter_keras=3)
-        model.fit(x_train, y_train_mono_2)
-        preds = model.predict(x_train, return_proba=False)
-        self.assertEqual(preds.shape, (len(x_train),))
-        proba = model.predict(x_train, return_proba=True)
-        self.assertEqual(proba.shape, (len(x_train), 2)) # 2 classes
-        preds = model.predict(x_train, return_proba=False, experimental_version=True)
-        self.assertEqual(preds.shape, (len(x_train),))
-        proba = model.predict(x_train, return_proba=True, experimental_version=True)
-        self.assertEqual(proba.shape, (len(x_train), 2)) # 2 classes
-        remove_dir(model_dir)
 
         # Classification - Mono-label - Multi-Classes
         model = ModelDenseClassifier(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False)
-        model.fit(x_train, y_train_mono_3)
-        preds = model.predict(x_train, return_proba=False)
-        self.assertEqual(preds.shape, (len(x_train),))
-        proba = model.predict(x_train, return_proba=True)
-        self.assertEqual(proba.shape, (len(x_train), 3)) # 3 classes
-        preds = model.predict(x_train, return_proba=False, experimental_version=True)
-        self.assertEqual(preds.shape, (len(x_train),))
-        proba = model.predict(x_train, return_proba=True, experimental_version=True)
-        self.assertEqual(proba.shape, (len(x_train), 3)) # 3 classes
-        remove_dir(model_dir)
-        # nb iter > 0
-        model = ModelDenseClassifier(model_dir=model_dir, batch_size=8, epochs=2, multi_label=False, nb_iter_keras=3)
         model.fit(x_train, y_train_mono_3)
         preds = model.predict(x_train, return_proba=False)
         self.assertEqual(preds.shape, (len(x_train),))
@@ -643,33 +505,9 @@ class ModelKerasTests(unittest.TestCase):
         proba = model.predict(x_train, return_proba=True, experimental_version=True)
         self.assertEqual(proba.shape, (len(x_train), len(y_col_multi)))
         remove_dir(model_dir)
-        # nb iter > 0
-        model = ModelDenseClassifier(model_dir=model_dir, batch_size=8, epochs=2, multi_label=True, nb_iter_keras=3)
-        model.fit(x_train, y_train_multi)
-        preds = model.predict(x_train)
-        self.assertEqual(preds.shape, (len(x_train), len(y_col_multi)))
-        proba = model.predict(x_train, return_proba=True)
-        self.assertEqual(proba.shape, (len(x_train), len(y_col_multi)))
-        preds = model.predict(x_train, return_proba=False, experimental_version=True)
-        self.assertEqual(preds.shape, (len(x_train), len(y_col_multi)))
-        proba = model.predict(x_train, return_proba=True, experimental_version=True)
-        self.assertEqual(proba.shape, (len(x_train), len(y_col_multi)))
-        remove_dir(model_dir)
 
         # Regressor
         model = ModelDenseRegressor(model_dir=model_dir, batch_size=8, epochs=2)
-        model.fit(x_train, y_train_regressor)
-        preds = model.predict(x_train)
-        self.assertEqual(preds.shape, (len(x_train),))
-        with self.assertRaises(ValueError):
-            proba = model.predict(x_train, return_proba=True)
-        preds = model.predict(x_train, experimental_version=True)
-        self.assertEqual(preds.shape, (len(x_train),))
-        with self.assertRaises(ValueError):
-            proba = model.predict(x_train, return_proba=True, experimental_version=True)
-        remove_dir(model_dir)
-        # nb iter > 0
-        model = ModelDenseRegressor(model_dir=model_dir, batch_size=8, epochs=2, nb_iter_keras=3)
         model.fit(x_train, y_train_regressor)
         preds = model.predict(x_train)
         self.assertEqual(preds.shape, (len(x_train),))
@@ -762,18 +600,6 @@ class ModelKerasTests(unittest.TestCase):
         self.assertEqual(checkpoint.filepath, os.path.join(model.model_dir, 'best.hdf5'))
         self.assertEqual(csv_logger.filename, os.path.join(model.model_dir, 'logger.csv'))
 
-        # iter > 0
-        callbacks = model._get_callbacks(2)
-        callbacks_types = [type(_) for _ in callbacks]
-        self.assertTrue(keras.callbacks.EarlyStopping in callbacks_types)
-        self.assertTrue(keras.callbacks.ModelCheckpoint in callbacks_types)
-        self.assertTrue(keras.callbacks.CSVLogger in callbacks_types)
-        self.assertTrue(keras.callbacks.TerminateOnNaN in callbacks_types)
-        checkpoint = callbacks[callbacks_types.index(keras.callbacks.ModelCheckpoint)]
-        csv_logger = callbacks[callbacks_types.index(keras.callbacks.CSVLogger)]
-        self.assertEqual(checkpoint.filepath, os.path.join(model.model_dir, 'best_2.hdf5'))
-        self.assertEqual(csv_logger.filename, os.path.join(model.model_dir, 'logger_2.csv'))
-
         # level save 'LOW'
         model.level_save = 'LOW'
         callbacks = model._get_callbacks()
@@ -840,7 +666,6 @@ class ModelKerasTests(unittest.TestCase):
         self.assertTrue('epochs' in configs.keys())
         self.assertTrue('validation_split' in configs.keys())
         self.assertTrue('patience' in configs.keys())
-        self.assertTrue('nb_iter_keras' in configs.keys())
         self.assertTrue('keras_params' in configs.keys())
         self.assertTrue('_get_model' in configs.keys())
         self.assertTrue('_get_learning_rate_scheduler' in configs.keys())
@@ -884,7 +709,6 @@ class ModelKerasTests(unittest.TestCase):
         self.assertTrue('epochs' in configs.keys())
         self.assertTrue('validation_split' in configs.keys())
         self.assertTrue('patience' in configs.keys())
-        self.assertTrue('nb_iter_keras' in configs.keys())
         self.assertTrue('keras_params' in configs.keys())
         self.assertTrue('_get_model' in configs.keys())
         self.assertTrue('_get_learning_rate_scheduler' in configs.keys())

--- a/gabarit/template_vision/vision_project/package_name/models_training/model_keras.py
+++ b/gabarit/template_vision/vision_project/package_name/models_training/model_keras.py
@@ -60,7 +60,6 @@ class ModelKeras(ModelClass):
     '''Generic model for Keras NN'''
 
     _default_name = 'model_keras'
-    nb_iter_keras: int
     # Not implemented :
     # -> _get_model
     # -> reload_from_standalone
@@ -396,7 +395,7 @@ class ModelKeras(ModelClass):
             # 2.
             best_path = os.path.join(self.model_dir, 'best.hdf5')
             time_spent = time.time() - start_time
-            if time_spent >= 60 and self.nb_iter_keras == 1 and os.path.exists(best_path):
+            if time_spent >= 60 and os.path.exists(best_path):
                 # 3.
                 self.model = load_model(best_path, custom_objects=self.custom_objects)
                 # 4.


### PR DESCRIPTION
## ✒️ Context

Removed all `nb_iter_keras` stuffs

  - [ ] Bugfix
  - [ ] Feature
  - [x] Refactoring
  - [ ] Other, please describe:

## 🧱 Description of Changes

Removed all refs to `nb_iter_keras` and removed corresponding tests & deps

  - [x] This is a change for the NLP template
  - [x] This is a change for the NUM template
  - [x] This is a change for the VISION template
  - [ ] This changes how templates are generated (i.e. a Jinja change)

## 🩺 Testing

- _Add bullet points summarizing your changes here_

  - [ ] This change does not need new tests
  - [x] Added/Updated unit tests
  - [ ] Added/Updated functionals tests (i.e. e2e)

## 🔗 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #26 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the GNU AFFERO GENERAL PUBLIC LICENSE.
