### PR TITLE
Feature/32 nlp predict proba functions should be mutualize in model keras

### DIFF
--- a/gabarit/template_nlp/nlp_project/package_name-tutorials/fr/jules_verne/model_author.py
+++ b/gabarit/template_nlp/nlp_project/package_name-tutorials/fr/jules_verne/model_author.py
@@ -102,7 +102,7 @@ class ModelAuthor(ModelTfidfSvm):
         return np.array(list_predictions)
 
     def predict_proba(self, x_test, **kwargs) -> np.ndarray:
-        '''Probabilities predicted on the test set
+        '''Predicts probabilities on the test dataset
 
         Args:
             x_test (?): Array-like or sparse matrix, shape = [n_samples, n_features]

--- a/gabarit/template_nlp/nlp_project/package_name/models_training/model_class.py
+++ b/gabarit/template_nlp/nlp_project/package_name/models_training/model_class.py
@@ -133,7 +133,7 @@ class ModelClass:
 
     @utils.data_agnostic_str_to_list
     def predict_proba(self, x_test, **kwargs) -> np.ndarray:
-        '''Probabilities predicted on the test set
+        '''Predicts probabilities on the test dataset
 
         Args:
             x_test (?): Array-like or sparse matrix, shape = [n_samples, n_features]

--- a/gabarit/template_nlp/nlp_project/package_name/models_training/model_embedding_cnn.py
+++ b/gabarit/template_nlp/nlp_project/package_name/models_training/model_embedding_cnn.py
@@ -82,28 +82,6 @@ class ModelEmbeddingCnn(ModelKeras):
         self.tokenizer: Any = None
         self.tokenizer_filters = tokenizer_filters
 
-    @utils.data_agnostic_str_to_list
-    @utils.trained_needed
-    def predict_proba(self, x_test, experimental_version: bool = False, **kwargs) -> np.ndarray:
-        '''Predicts probabilities on the test dataset
-
-        Warning, this provides probabilities for a single model.
-
-        Args:
-            x_test (?): Array-like or sparse matrix, shape = [n_samples, n_features]
-        Kwargs:
-            experimental_version (bool): If an experimental (but faster) version must be used
-        Returns:
-            (np.ndarray): Array, shape = [n_samples, n_classes]
-        '''
-        # Prepare input
-        x_test = self._prepare_x_test(x_test)
-        # Process
-        if experimental_version:
-            return self.experimental_predict_proba(x_test)
-        else:
-            return self.model.predict(x_test, batch_size=128, verbose=1)  # type: ignore
-
     def _prepare_x_train(self, x_train) -> np.ndarray:
         '''Prepares the input data for the model. Called when fitting the model
 

--- a/gabarit/template_nlp/nlp_project/package_name/models_training/model_embedding_lstm.py
+++ b/gabarit/template_nlp/nlp_project/package_name/models_training/model_embedding_lstm.py
@@ -84,29 +84,6 @@ class ModelEmbeddingLstm(ModelKeras):
         self.tokenizer: Any = None
         self.tokenizer_filters = tokenizer_filters
 
-    @utils.data_agnostic_str_to_list
-    @utils.trained_needed
-    def predict_proba(self, x_test, experimental_version: bool = False, **kwargs) -> np.ndarray:
-        '''Predicts probabilities on the test dataset
-
-        Warning, this provides probabilities for a single model.
-
-        Args:
-            x_test (?): Array-like or sparse matrix, shape = [n_samples, n_features]
-        Kwargs:
-            experimental_version (bool): If an experimental (but faster) version must be used
-        Returns:
-            (np.ndarray): Array, shape = [n_samples, n_classes]
-        '''
-        # Prepare input
-        x_test = self._prepare_x_test(x_test)
-        # Process
-        if experimental_version:
-            return self.experimental_predict_proba(x_test)
-        else:
-            return self.model.predict(x_test, batch_size=128, verbose=1)  # type: ignore
-
-
     def _prepare_x_train(self, x_train) -> np.ndarray:
         '''Prepares the input data for the model. Called when fitting the model
 

--- a/gabarit/template_nlp/nlp_project/package_name/models_training/model_embedding_lstm_attention.py
+++ b/gabarit/template_nlp/nlp_project/package_name/models_training/model_embedding_lstm_attention.py
@@ -89,28 +89,6 @@ class ModelEmbeddingLstmAttention(ModelKeras):
         self.tokenizer: Any = None
         self.tokenizer_filters = tokenizer_filters
 
-    @utils.data_agnostic_str_to_list
-    @utils.trained_needed
-    def predict_proba(self, x_test, experimental_version: bool = False, **kwargs) -> np.ndarray:
-        '''Predicts probabilities on the test dataset
-
-        Warning, this provides probabilities for a single model.
-
-        Args:
-            x_test (?): Array-like or sparse matrix, shape = [n_samples, n_features]
-        Kwargs:
-            experimental_version (bool): If an experimental (but faster) version must be used
-        Returns:
-            (np.ndarray): Array, shape = [n_samples, n_classes]
-        '''
-        # Prepare input
-        x_test = self._prepare_x_test(x_test)
-        # Process
-        if experimental_version:
-            return self.experimental_predict_proba(x_test)
-        else:
-            return self.model.predict(x_test, batch_size=128, verbose=1)  # type: ignore
-
     def _prepare_x_train(self, x_train) -> np.ndarray:
         '''Prepares the input data for the model. Called when fitting the model
 

--- a/gabarit/template_nlp/nlp_project/package_name/models_training/model_embedding_lstm_gru_gpu.py
+++ b/gabarit/template_nlp/nlp_project/package_name/models_training/model_embedding_lstm_gru_gpu.py
@@ -86,29 +86,6 @@ class ModelEmbeddingLstmGruGpu(ModelKeras):
         self.tokenizer: Any = None
         self.tokenizer_filters = tokenizer_filters
 
-    @utils.data_agnostic_str_to_list
-    @utils.trained_needed
-    def predict_proba(self, x_test, experimental_version: bool = False, **kwargs) -> np.ndarray:
-        '''Predicts probabilities on the test dataset
-
-        Warning, this provides probabilities for a single model.
-
-        Args:
-            x_test (?): Array-like or sparse matrix, shape = [n_samples, n_features]
-        Kwargs:
-            experimental_version (bool): If an experimental (but faster) version must be used
-        Returns:
-            (np.ndarray): Array, shape = [n_samples, n_classes]
-        '''
-        # Prepare input
-        x_test = self._prepare_x_test(x_test)
-        # Process
-        if experimental_version:
-            return self.experimental_predict_proba(x_test)
-        else:
-            return self.model.predict(x_test, batch_size=128, verbose=1)  # type: ignore
-
-
     def _prepare_x_train(self, x_train) -> np.ndarray:
         '''Prepares the input data for the model. Called when fitting the model
 

--- a/gabarit/template_nlp/nlp_project/package_name/models_training/model_embedding_lstm_structured_attention.py
+++ b/gabarit/template_nlp/nlp_project/package_name/models_training/model_embedding_lstm_structured_attention.py
@@ -94,29 +94,6 @@ class ModelEmbeddingLstmStructuredAttention(ModelKeras):
         self.tokenizer: Any = None
         self.tokenizer_filters = tokenizer_filters
 
-    @utils.data_agnostic_str_to_list
-    @utils.trained_needed
-    def predict_proba(self, x_test, experimental_version: bool = False, **kwargs) -> np.ndarray:
-        '''Predicts probabilities on the test dataset
-
-        Warning, this provides probabilities for a single model.
-
-        Args:
-            x_test (?): Array-like or sparse matrix, shape = [n_samples, n_features]
-        Kwargs:
-            experimental_version (bool): If an experimental (but faster) version must be used
-        Returns:
-            (np.ndarray): Array, shape = [n_samples, n_classes]
-        '''
-        # Prepare input
-        x_test = self._prepare_x_test(x_test)
-        # Process
-        if experimental_version:
-            return self.experimental_predict_proba(x_test)
-        else:
-            return self.model.predict(x_test, batch_size=128, verbose=1)  # type: ignore
-
-
     def _prepare_x_train(self, x_train) -> np.ndarray:
         '''Prepares the input data for the model. Called when fitting the model
 

--- a/gabarit/template_nlp/nlp_project/package_name/models_training/model_keras.py
+++ b/gabarit/template_nlp/nlp_project/package_name/models_training/model_keras.py
@@ -55,7 +55,6 @@ class ModelKeras(ModelClass):
     _default_name = 'model_keras'
 
     # Not implemented :
-    # -> predict_proba
     # -> _prepare_x_train
     # -> _prepare_x_test
     # -> _get_model
@@ -334,19 +333,27 @@ class ModelKeras(ModelClass):
 
     @utils.data_agnostic_str_to_list
     @utils.trained_needed
-    def predict_proba(self, x_test) -> np.ndarray:
-        '''Probabilities predicted on the test set
+    def predict_proba(self, x_test, experimental_version: bool = False, **kwargs) -> np.ndarray:
+        '''Predicts probabilities on the test dataset
 
         Args:
-            x_test (?): Array-like or sparse matrix, shape = [n_samples]
+            x_test (?): Array-like or sparse matrix, shape = [n_samples, n_features]
+        Kwargs:
+            experimental_version (bool): If an experimental (but faster) version must be used
         Returns:
             (np.ndarray): Array, shape = [n_samples, n_classes]
         '''
-        raise NotImplementedError("'predict_proba' needs to be overridden")
+        # Prepare input
+        x_test = self._prepare_x_test(x_test)
+        # Process
+        if experimental_version:
+            return self.experimental_predict_proba(x_test)
+        else:
+            return self.model.predict(x_test, batch_size=128, verbose=1)  # type: ignore
 
     @utils.trained_needed
     def experimental_predict_proba(self, x_test, **kwargs) -> np.ndarray:
-        '''Probabilities predicted on the test set - Experimental function
+        '''Predicts probabilities on the test dataset - Experimental function
         Preprocessings must be done before (in predict_proba)
         Here we only do the prediction and return the result
 

--- a/gabarit/template_nlp/nlp_project/package_name/models_training/model_pipeline.py
+++ b/gabarit/template_nlp/nlp_project/package_name/models_training/model_pipeline.py
@@ -125,7 +125,7 @@ class ModelPipeline(ModelClass):
     @utils.data_agnostic_str_to_list
     @utils.trained_needed
     def predict_proba(self, x_test, **kwargs) -> np.ndarray:
-        '''Probabilities predicted on the test set
+        '''Predicts probabilities on the test dataset
 
         Args:
             x_test (?): Array-like or sparse matrix, shape = [n_samples, n_features]

--- a/gabarit/template_nlp/nlp_project/package_name/models_training/model_pytorch.py
+++ b/gabarit/template_nlp/nlp_project/package_name/models_training/model_pytorch.py
@@ -331,7 +331,7 @@ class ModelPyTorch(ModelClass):
     @utils.data_agnostic_str_to_list
     @utils.trained_needed
     def predict_proba(self, x_test, **kwargs) -> np.ndarray:
-        '''Probabilities predicted on the test set
+        '''Predicts probabilities on the test dataset
 
         Args:
             x_test (?): Array-like or sparse matrix, shape = [n_samples]

--- a/gabarit/template_nlp/nlp_project/package_name/models_training/model_tfidf_dense.py
+++ b/gabarit/template_nlp/nlp_project/package_name/models_training/model_tfidf_dense.py
@@ -63,26 +63,6 @@ class ModelTfidfDense(ModelKeras):
             tfidf_params = {}
         self.tfidf = TfidfVectorizer(**tfidf_params)
 
-    @utils.data_agnostic_str_to_list
-    @utils.trained_needed
-    def predict_proba(self, x_test, experimental_version: bool = False, **kwargs) -> np.ndarray:
-        '''Probabilies predictions on the test dataset.
-
-        Args:
-            x_test (?): Array-like or sparse matrix, shape = [n_samples]
-        Kwargs:
-            experimental_version (bool): If an experimental (but faster) version must be used
-        Returns:
-            (np.ndarray): Array, shape = [n_samples, n_classes]
-        '''
-        # Prepare input
-        x_test = self._prepare_x_test(x_test)
-        # Process
-        if experimental_version:
-            return self.experimental_predict_proba(x_test)
-        else:
-            return self.model.predict(x_test, batch_size=128, verbose=1)  # type: ignore
-
     def _prepare_x_train(self, x_train) -> np.ndarray:
         '''Prepares the input data for the model. Called when fitting the model
 

--- a/gabarit/template_num/num_project/package_name/models_training/classifiers/model_gbt_classifier.py
+++ b/gabarit/template_num/num_project/package_name/models_training/classifiers/model_gbt_classifier.py
@@ -95,6 +95,9 @@ class ModelGBTClassifier(ModelClassifierMixin, ModelPipeline):
         if self.multi_label or self.multiclass_strategy != 'ovo':
             return super().predict_proba(x_test=x_test, **kwargs)
         else:
+            # We check input format
+            x_test, _ = self._check_input_format(x_test)
+            # Get preds
             preds = self.pipeline.predict(x_test)
             # Format ['a', 'b', 'c', 'a', ..., 'b']
             # Transform to "proba"

--- a/gabarit/template_num/num_project/package_name/models_training/classifiers/model_knn_classifier.py
+++ b/gabarit/template_num/num_project/package_name/models_training/classifiers/model_knn_classifier.py
@@ -93,6 +93,9 @@ class ModelKNNClassifier(ModelClassifierMixin, ModelPipeline):
         if self.multi_label or self.multiclass_strategy != 'ovo':
             return super().predict_proba(x_test=x_test, **kwargs)
         else:
+            # We check input format
+            x_test, _ = self._check_input_format(x_test)
+            # Get preds
             preds = self.pipeline.predict(x_test)
             # Format ['a', 'b', 'c', 'a', ..., 'b']
             # Transform to "proba"

--- a/gabarit/template_num/num_project/package_name/models_training/classifiers/model_lgbm_classifier.py
+++ b/gabarit/template_num/num_project/package_name/models_training/classifiers/model_lgbm_classifier.py
@@ -94,6 +94,9 @@ class ModelLGBMClassifier(ModelClassifierMixin, ModelPipeline):
         if self.multi_label or self.multiclass_strategy != 'ovo':
             return super().predict_proba(x_test=x_test, **kwargs)
         else:
+            # We check input format
+            x_test, _ = self._check_input_format(x_test)
+            # Get preds
             preds = self.pipeline.predict(x_test)
             # Format ['a', 'b', 'c', 'a', ..., 'b']
             # Transform to "proba"

--- a/gabarit/template_num/num_project/package_name/models_training/classifiers/model_logistic_regression_classifier.py
+++ b/gabarit/template_num/num_project/package_name/models_training/classifiers/model_logistic_regression_classifier.py
@@ -94,6 +94,9 @@ class ModelLogisticRegressionClassifier(ModelClassifierMixin, ModelPipeline):
         if self.multi_label or self.multiclass_strategy != 'ovo':
             return super().predict_proba(x_test=x_test, **kwargs)
         else:
+            # We check input format
+            x_test, _ = self._check_input_format(x_test)
+            # Get preds
             preds = self.pipeline.predict(x_test)
             # Format ['a', 'b', 'c', 'a', ..., 'b']
             # Transform to "proba"

--- a/gabarit/template_num/num_project/package_name/models_training/classifiers/model_rf_classifier.py
+++ b/gabarit/template_num/num_project/package_name/models_training/classifiers/model_rf_classifier.py
@@ -93,6 +93,9 @@ class ModelRFClassifier(ModelClassifierMixin, ModelPipeline):
         if self.multi_label or self.multiclass_strategy != 'ovo':
             return super().predict_proba(x_test=x_test, **kwargs)
         else:
+            # We check input format
+            x_test, _ = self._check_input_format(x_test)
+            # Get preds
             preds = self.pipeline.predict(x_test)
             # Format ['a', 'b', 'c', 'a', ..., 'b']
             # Transform to "proba"

--- a/gabarit/template_num/num_project/package_name/models_training/classifiers/model_ridge_classifier.py
+++ b/gabarit/template_num/num_project/package_name/models_training/classifiers/model_ridge_classifier.py
@@ -90,6 +90,9 @@ class ModelRidgeClassifier(ModelClassifierMixin, ModelPipeline):
         Returns:
             (np.ndarray): Array, shape = [n_samples, n_classes]
         '''
+        # We check input format
+        x_test, _ = self._check_input_format(x_test)
+        # Get preds
         if not self.multi_label:
             preds = self.pipeline.predict(x_test)
             # Format ['a', 'b', 'c', 'a', ..., 'b']

--- a/gabarit/template_num/num_project/package_name/models_training/classifiers/model_sgd_classifier.py
+++ b/gabarit/template_num/num_project/package_name/models_training/classifiers/model_sgd_classifier.py
@@ -92,6 +92,9 @@ class ModelSGDClassifier(ModelClassifierMixin, ModelPipeline):
         '''
         # Can't use probabilities if loss not in ['log', 'modified_huber'] or 'ovo' and not multi-labels
         if self.sgd.loss not in ['log', 'modified_huber'] or (self.multiclass_strategy == 'ovo' and not self.multi_label):
+            # We check input format
+            x_test, _ = self._check_input_format(x_test)
+            # Get preds
             if not self.multi_label:
                 preds = self.pipeline.predict(x_test)
                 # Format ['a', 'b', 'c', 'a', ..., 'b']

--- a/gabarit/template_num/num_project/package_name/models_training/classifiers/model_svm_classifier.py
+++ b/gabarit/template_num/num_project/package_name/models_training/classifiers/model_svm_classifier.py
@@ -91,7 +91,8 @@ class ModelSVMClassifier(ModelClassifierMixin, ModelPipeline):
         Returns:
             (np.ndarray): Array, shape = [n_samples, n_classes]
         '''
-        # Uses super() of the ModelPipeline class if != 'ovo' or multi-labels
+        # We check input format
+        x_test, _ = self._check_input_format(x_test)
         if not self.multi_label:
             preds = self.pipeline.predict(x_test)
             # Format ['a', 'b', 'c', 'a', ..., 'b']

--- a/gabarit/template_num/num_project/package_name/models_training/model_class.py
+++ b/gabarit/template_num/num_project/package_name/models_training/model_class.py
@@ -155,7 +155,7 @@ class ModelClass:
         raise NotImplementedError("'predict' needs to be overridden")
 
     def predict_proba(self, x_test: pd.DataFrame, **kwargs) -> np.ndarray:
-        '''Probabilities predicted on the test set
+        '''Predicts probabilities on the test dataset
 
         Args:
             x_test (pd.DataFrame): DataFrame with the test data to be predicted

--- a/gabarit/template_vision/vision_project/package_name/models_training/model_class.py
+++ b/gabarit/template_vision/vision_project/package_name/models_training/model_class.py
@@ -121,7 +121,7 @@ class ModelClass:
         raise NotImplementedError("'predict' needs to be overridden")
 
     def predict_proba(self, df_test: pd.DataFrame, **kwargs) -> np.ndarray:
-        '''Probabilities predicted on the test set
+        '''Predicts probabilities on the test dataset
 
         Args:
             df_test (pd.DataFrame): DataFrame to be predicted, with column file_path

--- a/gabarit/template_vision/vision_project/package_name/models_training/model_keras.py
+++ b/gabarit/template_vision/vision_project/package_name/models_training/model_keras.py
@@ -536,7 +536,7 @@ class ModelKeras(ModelClass):
 
     @utils.trained_needed
     def predict_proba(self, df_test, batch_size: int = None) -> np.ndarray:
-        '''Probabilities predicted on the test set
+        '''Predicts probabilities on the test dataset
 
         Args:
             df_test (pd.DataFrame): DataFrame to be predicted, with column file_path


### PR DESCRIPTION
## ✒️ Context

Many `predict_proba` function could be mutualize in the NLP template.
We also add some checks in the template NUM.

- What kind of change does this PR introduce ?

  - [ ] Bugfix
  - [ ] Feature
  - [x] Refactoring
  - [ ] Other, please describe:

## 🧱 Description of Changes

- _Add bullet points summarizing your changes here_

  - [x] This is a change for the NLP template
  - [x] This is a change for the NUM template
  - [ ] This is a change for the VISION template
  - [ ] This changes how templates are generated (i.e. a Jinja change)

## 🩺 Testing

- _Add bullet points summarizing your changes here_

  - [x] This change does not need new tests
  - [ ] Added/Updated unit tests
  - [ ] Added/Updated functionals tests (i.e. e2e)

## 🔗 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #32 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the GNU AFFERO GENERAL PUBLIC LICENSE.
