### PR TITLE
issue#48 : use get_feature_names_out from sklearn

### DIFF
--- a/gabarit/template_num/num_project/package_name/preprocessing/preprocess.py
+++ b/gabarit/template_num/num_project/package_name/preprocessing/preprocess.py
@@ -152,29 +152,5 @@ def retrieve_columns_from_pipeline(df: pd.DataFrame, pipeline: ColumnTransformer
     return df
 
 
-# TODO: Check if the estimators all have the method get_feature_names_out implemented (https://github.com/scikit-learn/scikit-learn/issues/21308)
-# to replace these functions
-def get_feature_out(estimator, features_in: list) -> list:
-    '''Gets the name of a column when considering a fitted estimator
-    From: https://stackoverflow.com/questions/57528350/can-you-consistently-keep-track-of-column-labels-using-sklearns-transformer-api
-
-    Args:
-        (?): Estimator to be processed
-        (list): Input columns
-    Returns:
-        list: List of new feature names
-    '''
-    if hasattr(estimator, 'get_feature_names'):
-        if isinstance(estimator, _VectorizerMixin):
-            # handling all vectorizers
-            return [f'vec_{f}' for f in estimator.get_feature_names()]
-        else:
-            return estimator.get_feature_names(features_in)
-    elif isinstance(estimator, SelectorMixin):
-        return np.array(features_in)[estimator.get_support()]
-    else:
-        return features_in
-
-
 if __name__ == '__main__':
     logger.error("This script is not stand alone but belongs to a package that has to be imported.")

--- a/gabarit/template_num/num_project/package_name/preprocessing/preprocess.py
+++ b/gabarit/template_num/num_project/package_name/preprocessing/preprocess.py
@@ -191,7 +191,8 @@ def get_ct_feature_names(ct: ColumnTransformer) -> list:
                 features_out = get_feature_out(estimator, features)
             output_features.extend([f'{name}__{feat}' for feat in features_out])
         elif estimator == 'passthrough':
-            output_features.extend([f'remainder__{feat}' for feat in features])
+            # features is indexes in case of passthrough
+            output_features.extend([f'remainder__{feat}' for feat in ct.feature_names_in_[features]])
 
     return output_features
 

--- a/gabarit/template_num/num_project/package_name/preprocessing/preprocess.py
+++ b/gabarit/template_num/num_project/package_name/preprocessing/preprocess.py
@@ -139,7 +139,7 @@ def retrieve_columns_from_pipeline(df: pd.DataFrame, pipeline: ColumnTransformer
         # Check if fitted:
         if not hasattr(pipeline, '_columns'):
             raise AttributeError("The pipeline must be fitted to use the function retrieve_columns_from_pipeline")
-        new_columns = get_ct_feature_names(pipeline)
+        new_columns = pipeline.get_feature_names_out()
         assert len(new_columns) == df.shape[1], "There is a discrepancy in the number of columns" +\
                                                 f" between the preprocessed DataFrame ({df.shape[1]})" +\
                                                 f" and the pipeline ({len(new_columns)})."
@@ -150,40 +150,6 @@ def retrieve_columns_from_pipeline(df: pd.DataFrame, pipeline: ColumnTransformer
         logger.error("Continue the process")
         logger.error(repr(e))
     return df
-
-
-# TODO: Use new get_feature_names_out functionality
-# https://scikit-learn.org/stable/auto_examples/release_highlights/plot_release_highlights_1_0_0.html#feature-names-support
-def get_ct_feature_names(ct: ColumnTransformer) -> list:
-    '''Gets the names of the columns when considering a fitted ColumnTransfomer
-    From: https://stackoverflow.com/questions/57528350/can-you-consistently-keep-track-of-column-labels-using-sklearns-transformer-api
-
-    Args:
-        ColumnTransformer: Column tranformer to be processed
-    Returns:
-        list: List of new feature names
-    '''
-    # Handles all estimators, pipelines inside ColumnTransfomer
-    # does not work when remainder =='passthrough'
-    # which requires the input column names.
-    output_features = []
-
-    for name, estimator, features in ct.transformers_:
-        if name != 'remainder':
-            if isinstance(estimator, Pipeline):
-                current_features = features
-                for step in estimator:
-                    if type(step) == tuple:
-                        step = step[1]
-                    current_features = get_feature_out(step, current_features)
-                features_out = current_features
-            else:
-                features_out = get_feature_out(estimator, features)
-            output_features.extend(features_out)
-        elif estimator == 'passthrough':
-            output_features.extend(ct.feature_names_in_[features])
-
-    return output_features
 
 
 # TODO: Check if the estimators all have the method get_feature_names_out implemented (https://github.com/scikit-learn/scikit-learn/issues/21308)

--- a/gabarit/template_num/num_project/package_name/preprocessing/preprocess.py
+++ b/gabarit/template_num/num_project/package_name/preprocessing/preprocess.py
@@ -189,10 +189,16 @@ def get_ct_feature_names(ct: ColumnTransformer) -> list:
                 features_out = current_features
             else:
                 features_out = get_feature_out(estimator, features)
-            output_features.extend([f'{name}__{feat}' for feat in features_out])
+            if hasattr(ct, 'verbose_feature_names_out') and ct.verbose_feature_names_out == False:
+                output_features.extend(features_out)
+            else:
+                output_features.extend([f'{name}__{feat}' for feat in features_out])
         elif estimator == 'passthrough':
             # features is indexes in case of passthrough
-            output_features.extend([f'remainder__{feat}' for feat in ct.feature_names_in_[features]])
+            if hasattr(ct, 'verbose_feature_names_out') and ct.verbose_feature_names_out == False:
+                output_features.extend(ct.feature_names_in_[features])
+            else:
+                output_features.extend([f'remainder__{feat}' for feat in ct.feature_names_in_[features]])
 
     return output_features
 

--- a/gabarit/template_num/num_project/tests/test_preprocess.py
+++ b/gabarit/template_num/num_project/tests/test_preprocess.py
@@ -167,7 +167,8 @@ class PreprocessTests(unittest.TestCase):
             ('tr2', col_2_pipeline, ['col_2']),
             ('tr3', text_pipeline, 'text'),
         ]
-        pipeline = ColumnTransformer(transformers, remainder='drop')
+        pipeline = ColumnTransformer(transformers, remainder='drop', verbose_feature_names_out=False)
+        pipeline_verbose = ColumnTransformer(transformers, remainder='drop', verbose_feature_names_out=True)
         # DataFrame
         df = pd.DataFrame({'col_1': [1, 5, 8, 4], 'col_2': [0.0, None, 1.0, 1.0], 'col_3': [-5, 6, 8, 6],
                            'toto': [4, 8, 9, 4],
@@ -176,16 +177,23 @@ class PreprocessTests(unittest.TestCase):
         y = pd.Series([1, 1, 1, 0])
         # Fit
         pipeline.fit(df, y)
+        pipeline_verbose.fit(df, y)
 
         # Nominal case
         output_features = preprocess.get_ct_feature_names(pipeline)
-        self.assertEqual(output_features, ['tr1__col_1', 'tr1__col_3', 'tr2__col_2_0.0', 'tr2__col_2_1.0', 'tr3__dernier', 'tr3__test'])
+        output_features_verbose = preprocess.get_ct_feature_names(pipeline_verbose)
+        self.assertEqual(output_features, ['col_1', 'col_3', 'col_2_0.0', 'col_2_1.0', 'dernier', 'test'])
+        self.assertEqual(output_features_verbose, ['tr1__col_1', 'tr1__col_3', 'tr2__col_2_0.0', 'tr2__col_2_1.0', 'tr3__dernier', 'tr3__test'])
 
         # remainder == 'passthrough'
-        pipeline = ColumnTransformer(transformers, remainder='passthrough')
+        pipeline = ColumnTransformer(transformers, remainder='passthrough', verbose_feature_names_out=False)
+        pipeline_verbose = ColumnTransformer(transformers, remainder='passthrough', verbose_feature_names_out=True)
         pipeline.fit(df, y)
+        pipeline_verbose.fit(df, y)
         output_features = preprocess.get_ct_feature_names(pipeline)
-        self.assertEqual(output_features, ['tr1__col_1', 'tr1__col_3', 'tr2__col_2_0.0', 'tr2__col_2_1.0', 'tr3__dernier', 'tr3__test', 'remainder__toto'])
+        output_features_verbose = preprocess.get_ct_feature_names(pipeline_verbose)
+        self.assertEqual(output_features, ['col_1', 'col_3', 'col_2_0.0', 'col_2_1.0', 'dernier', 'test', 'toto'])
+        self.assertEqual(output_features_verbose, ['tr1__col_1', 'tr1__col_3', 'tr2__col_2_0.0', 'tr2__col_2_1.0', 'tr3__dernier', 'tr3__test', 'remainder__toto'])
 
 
     def test05_get_feature_out(self):

--- a/gabarit/template_num/num_project/tests/test_preprocess.py
+++ b/gabarit/template_num/num_project/tests/test_preprocess.py
@@ -97,7 +97,7 @@ class PreprocessTests(unittest.TestCase):
             ('col_2', col_2_pipeline, ['col_2']),
             ('text', text_pipeline, 'text'),
         ]
-        pipeline = ColumnTransformer(transformers, remainder='drop')
+        pipeline = ColumnTransformer(transformers, remainder='drop', verbose_feature_names_out=False)
         # DataFrame
         df = pd.DataFrame({'col_1': [1, 5, 8, 4], 'col_2': [0.0, None, 1.0, 1.0], 'col_3': [-5, 6, 8, 6],
                            'toto': [4, 8, 9, 4],
@@ -111,10 +111,10 @@ class PreprocessTests(unittest.TestCase):
 
         # Nominal case
         new_transformed_df = preprocess.retrieve_columns_from_pipeline(transformed_df, pipeline)
-        self.assertEqual(list(new_transformed_df.columns), ['col_1', 'col_3', 'col_2_0.0', 'col_2_1.0', 'vec_dernier', 'vec_test'])
+        self.assertEqual(list(new_transformed_df.columns), ['col_1', 'col_3', 'col_2_0.0', 'col_2_1.0', 'dernier', 'test'])
 
         # If unfitted pipeline, no modifications
-        tmp_pipeline = ColumnTransformer(transformers, remainder='drop')
+        tmp_pipeline = ColumnTransformer(transformers, remainder='drop', verbose_feature_names_out=False)
         new_transformed_df = preprocess.retrieve_columns_from_pipeline(transformed_df, tmp_pipeline)
         pd.testing.assert_frame_equal(new_transformed_df, transformed_df)
 
@@ -145,38 +145,6 @@ class PreprocessTests(unittest.TestCase):
         estimator.fit(pd.DataFrame({'col_1': [0, 0, 1, 1, 1], 'col_2': [1, 1, 0, 0, 0], 'col_3': [0, 0, 0, 0, 0]}), pd.Series([-1, -1, 1, 1, 1]))
         feature_out = preprocess.get_feature_out(estimator, ['col_1', 'col_2', 'col_3'])
         self.assertEqual(list(feature_out), ['col_1', 'col_2'])
-
-
-    def test05_get_ct_feature_names(self):
-        '''Test of the function preprocess.get_ct_feature_names'''
-        # Pipeline
-        col_1_3_pipeline = make_pipeline(SimpleImputer(strategy='median'), StandardScaler())
-        col_2_pipeline = make_pipeline(SimpleImputer(strategy='most_frequent'), OneHotEncoder(handle_unknown='ignore'))
-        text_pipeline = make_pipeline(CountVectorizer(), SelectKBest(k=2))
-        transformers = [
-            ('col_1_3', col_1_3_pipeline, ['col_1', 'col_3']),
-            ('col_2', col_2_pipeline, ['col_2']),
-            ('text', text_pipeline, 'text'),
-        ]
-        pipeline = ColumnTransformer(transformers, remainder='drop')
-        # DataFrame
-        df = pd.DataFrame({'col_1': [1, 5, 8, 4], 'col_2': [0.0, None, 1.0, 1.0], 'col_3': [-5, 6, 8, 6],
-                           'toto': [4, 8, 9, 4],
-                           'text': ['ceci est un test', 'un autre test', 'et un troisième test', 'et un dernier']})
-        # Target
-        y = pd.Series([1, 1, 1, 0])
-        # Fit
-        pipeline.fit(df, y)
-
-        # Nominal case
-        output_features = preprocess.get_ct_feature_names(pipeline)
-        self.assertEqual(output_features, ['col_1', 'col_3', 'col_2_0.0', 'col_2_1.0', 'vec_dernier', 'vec_test'])
-
-        # remainder == 'passthrough'
-        pipeline = ColumnTransformer(transformers, remainder='passthrough')
-        pipeline.fit(df, y)
-        output_features = preprocess.get_ct_feature_names(pipeline)
-        self.assertEqual(output_features, ['col_1', 'col_3', 'col_2_0.0', 'col_2_1.0', 'vec_dernier', 'vec_test', 'toto'])
 
 
 # Perform tests

--- a/gabarit/template_num/num_project/tests/test_preprocess.py
+++ b/gabarit/template_num/num_project/tests/test_preprocess.py
@@ -123,30 +123,6 @@ class PreprocessTests(unittest.TestCase):
         pd.testing.assert_frame_equal(new_transformed_df, df)
 
 
-    def test04_get_feature_out(self):
-        '''Test of the function preprocess.get_feature_out'''
-
-        # Nominal case - non _VectorizerMixin - non SelectorMixin
-        estimator = SimpleImputer(strategy='median')
-        estimator.fit(pd.DataFrame({'col': [1, 0, 1, 1, None]}))
-        feature_out = preprocess.get_feature_out(estimator, 'toto')
-        self.assertEqual(feature_out, 'toto')
-        feature_out = preprocess.get_feature_out(estimator, ['toto', 'tata'])
-        self.assertEqual(feature_out, ['toto', 'tata'])
-
-        # Nominal case - _VectorizerMixin
-        estimator = OneHotEncoder(handle_unknown='ignore')
-        estimator.fit(pd.DataFrame({'col': [0, 0, 1, 1, 0]}))
-        feature_out = preprocess.get_feature_out(estimator, ['toto'])
-        self.assertEqual(list(feature_out), ['toto_0', 'toto_1'])
-
-        # Nominal case - SelectorMixin
-        estimator = SelectKBest(k=2)
-        estimator.fit(pd.DataFrame({'col_1': [0, 0, 1, 1, 1], 'col_2': [1, 1, 0, 0, 0], 'col_3': [0, 0, 0, 0, 0]}), pd.Series([-1, -1, 1, 1, 1]))
-        feature_out = preprocess.get_feature_out(estimator, ['col_1', 'col_2', 'col_3'])
-        self.assertEqual(list(feature_out), ['col_1', 'col_2'])
-
-
 # Perform tests
 if __name__ == '__main__':
     # Start tests

--- a/gabarit/template_num/num_tests/functional_tests.py
+++ b/gabarit/template_num/num_tests/functional_tests.py
@@ -152,12 +152,12 @@ class Case1_e2e_pipeline(unittest.TestCase):
         # Check if exists
         self.assertTrue(os.path.exists(os.path.join(full_path_lib, 'test_template_num-data', 'mono_class_mono_label_train_preprocess_P1.csv')))
         df_train = pd.read_csv(os.path.join(full_path_lib, 'test_template_num-data', 'mono_class_mono_label_train_preprocess_P1.csv'), sep=';', encoding='utf-8', skiprows=1)
-        # Check col col_1, col_2 & y_col exists
-        self.assertTrue('col_1' in df_train.columns)
-        self.assertTrue('col_2' in df_train.columns)
+        # Check col num__col_1, num__col_2 & y_col exists, num is the transformer name
+        self.assertTrue('num__col_1' in df_train.columns)
+        self.assertTrue('num__col_2' in df_train.columns)
         self.assertTrue('y_col' in df_train.columns)
         # Check col x_col_1 value
-        self.assertTrue(df_train['col_1'].values[2], 0.4142585780542456)
+        self.assertTrue(df_train['num__col_1'].values[2], 0.4142585780542456)
         # Check col y_col values
         self.assertEqual(sorted(df_train.y_col.unique()), ["non", "oui"])
         # Check pipeline has been saved
@@ -174,12 +174,12 @@ class Case1_e2e_pipeline(unittest.TestCase):
         # Check if exists
         self.assertTrue(os.path.exists(os.path.join(full_path_lib, 'test_template_num-data', 'mono_output_regression_train_preprocess_P1.csv')))
         df_train = pd.read_csv(os.path.join(full_path_lib, 'test_template_num-data', 'mono_output_regression_train_preprocess_P1.csv'), sep=';', encoding='utf-8', skiprows=1)
-        # Check col col_1, col_2 & y_col exists
-        self.assertTrue('col_1' in df_train.columns)
-        self.assertTrue('col_2' in df_train.columns)
+        # Check col num__col_1, num__col_2 & y_col exists, num is the transformer name
+        self.assertTrue('num__col_1' in df_train.columns)
+        self.assertTrue('num__col_2' in df_train.columns)
         self.assertTrue('y_col' in df_train.columns)
         # Check col x_col_1 value
-        self.assertTrue(df_train['col_1'].values[2], 0.4142585780542456)
+        self.assertTrue(df_train['num__col_1'].values[2], 0.4142585780542456)
         # Check pipeline has been saved
         pipelines_dirpath = os.path.join(full_path_lib, 'test_template_num-pipelines')
         self.assertTrue(os.path.exists(pipelines_dirpath))
@@ -212,8 +212,8 @@ class Case1_e2e_pipeline(unittest.TestCase):
         # Check same preprocess (we test unique values)
         df_train = pd.read_csv(train_path, sep=';', encoding='utf-8', skiprows=1)
         df_valid = pd.read_csv(valid_path, sep=';', encoding='utf-8', skiprows=1)
-        self.assertEqual(sorted(df_train.col_1.unique()), sorted(df_valid.col_1.unique()))
-        self.assertEqual(sorted(df_train.col_2.unique()), sorted(df_valid.col_2.unique()))
+        self.assertEqual(sorted(df_train.num__col_1.unique()), sorted(df_valid.num__col_1.unique()))
+        self.assertEqual(sorted(df_train.num__col_2.unique()), sorted(df_valid.num__col_2.unique()))
         self.assertEqual(sorted(df_train.y_col.unique()), sorted(df_valid.y_col.unique()))
 
         # "Basic" case - regression
@@ -232,8 +232,8 @@ class Case1_e2e_pipeline(unittest.TestCase):
         # Check same preprocess (we test unique values)
         df_train = pd.read_csv(train_path, sep=';', encoding='utf-8', skiprows=1)
         df_valid = pd.read_csv(valid_path, sep=';', encoding='utf-8', skiprows=1)
-        self.assertEqual(sorted(df_train.col_1.unique()), sorted(df_valid.col_1.unique()))
-        self.assertEqual(sorted(df_train.col_2.unique()), sorted(df_valid.col_2.unique()))
+        self.assertEqual(sorted(df_train.num__col_1.unique()), sorted(df_valid.num__col_1.unique()))
+        self.assertEqual(sorted(df_train.num__col_2.unique()), sorted(df_valid.num__col_2.unique()))
         self.assertEqual(sorted(df_train.y_col.unique()), sorted(df_valid.y_col.unique()))
 
     def test06_TrainingE2E(self):


### PR DESCRIPTION
## ✒️ Context

Issue #48 

- What kind of change does this PR introduce ?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧱 Description of Changes

Replace `get_ct_feature_names` by `get_feature_names_out` from [sklearn.compose.ColumnTransformer](https://scikit-learn.org/1.0/modules/generated/sklearn.compose.ColumnTransformer.html#sklearn.compose.ColumnTransformer.get_feature_names_out)

  - [ ] This is a change for the NLP template
  - [x] This is a change for the NUM template
  - [ ] This is a change for the VISION template
  - [ ] This changes how templates are generated (i.e. a Jinja change)

## 🩺 Testing

- Remove `test05_get_ct_feature_names`
- Update expected columns name from `test03_retrieve_columns_from_pipeline`

  - [ ] This change does not need new tests
  - [x] Added/Updated unit tests
  - [ ] Added/Updated functionals tests (i.e. e2e)

## 🔗 References

- **Issue**: Closes #48 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the GNU AFFERO GENERAL PUBLIC LICENSE.
