### PR TITLE
feat: numpy objects convertion and fix 104

### DIFF
--- a/gabarit/template_nlp/nlp_project/package_name/monitoring/model_explainer.py
+++ b/gabarit/template_nlp/nlp_project/package_name/monitoring/model_explainer.py
@@ -26,6 +26,7 @@ from typing import Type, Union, Any, Iterable
 from lime.explanation import Explanation
 from lime.lime_text import LimeTextExplainer
 
+from ..utils import ndarray_to_builtin_object, is_ndarray_convertable
 from ..preprocessing import preprocess
 from ..models_training.model_class import ModelClass
 
@@ -140,6 +141,10 @@ class LimeExplainer(Explainer):
         Returns:
             (?): An explanation object
         '''
+        # If a numpy object is passed as class_or_label_index we convert it to an object of a builtin type
+        if is_ndarray_convertable(class_or_label_index):
+            class_or_label_index = ndarray_to_builtin_object(class_or_label_index)
+
         if class_or_label_index is None:
             probas = self.classifier_fn([content])[0]
             class_or_label_index = (i for i, p in enumerate(probas) if p >= 0.5)

--- a/gabarit/template_nlp/nlp_project/package_name/utils.py
+++ b/gabarit/template_nlp/nlp_project/package_name/utils.py
@@ -203,13 +203,13 @@ def is_ndarray_convertable(obj: Union[np.ndarray, Any]) -> bool:
     return hasattr(obj, "dtype") and hasattr(obj, "astype") and hasattr(obj, "tolist")
 
 
-def ndarray_to_builtin_object(obj: np.ndarray) -> Any:
-    '''Transform a numpy.ndarray to a builtin type like int, float or list of ints
+def ndarray_to_builtin_object(obj: Any) -> Any:
+    '''Transform a numpy.ndarray like object to a builtin type like int, float or list
 
     Args:
-        obj (np.ndarray): numpy.ndarray object
+        obj (Any): An object
     Returns:
-        Any: list containing builtin types like int or float
+        Any: The object converted to a builtin type like int, float or list
     '''
     if is_ndarray_convertable(obj):
         if np.issubdtype(obj.dtype, np.integer):

--- a/gabarit/template_nlp/nlp_project/package_name/utils.py
+++ b/gabarit/template_nlp/nlp_project/package_name/utils.py
@@ -192,6 +192,36 @@ def data_agnostic_str_to_list(function: Callable) -> Callable:
     return wrapper
 
 
+def is_ndarray_convertable(obj: Union[np.ndarray, Any]) -> bool:
+    '''Returns True if the object is covertable to a builtin type in the same way a np.ndarray is
+    
+    Args:
+        obj (Union[np.ndarray, Any]): an object to test
+    Returns:
+        bool: True if the object is covertable to a list as a np.ndarray is
+    '''
+    return hasattr(obj, "dtype") and hasattr(obj, "astype") and hasattr(obj, "tolist")
+
+
+def ndarray_to_builtin_object(obj: np.ndarray) -> Any:
+    '''Transform a numpy.ndarray to a builtin type like int, float or list of ints
+
+    Args:
+        obj (np.ndarray): numpy.ndarray object
+    Returns:
+        Any: list containing builtin types like int or float
+    '''
+    if is_ndarray_convertable(obj):
+        if np.issubdtype(obj.dtype, np.integer):
+            return obj.astype(int).tolist()
+        elif np.issubdtype(obj.dtype, np.number):
+            return obj.astype(float).tolist()
+        else:
+            return obj.tolist()
+    else:
+        return obj
+
+
 def trained_needed(function: Callable) -> Callable:
     '''Decorator to ensure that a model has been trained.
 
@@ -319,12 +349,10 @@ def find_folder_path(folder_name: str, base_folder: Union[str, None] = None) -> 
 class NpEncoder(json.JSONEncoder):
     '''JSON encoder to manage numpy objects'''
     def default(self, obj) -> Any:
-        if isinstance(obj, np.integer):
-            return int(obj)
-        elif isinstance(obj, np.floating):
-            return float(obj)
-        elif isinstance(obj, np.ndarray):
-            return obj.tolist()
+        if is_ndarray_convertable(obj):
+            return ndarray_to_builtin_object(obj)
+        elif isinstance(obj, set):
+            return list(obj)
         else:
             return super(NpEncoder, self).default(obj)
 

--- a/gabarit/template_nlp/nlp_project/package_name/utils.py
+++ b/gabarit/template_nlp/nlp_project/package_name/utils.py
@@ -192,11 +192,11 @@ def data_agnostic_str_to_list(function: Callable) -> Callable:
     return wrapper
 
 
-def is_ndarray_convertable(obj: Union[np.ndarray, Any]) -> bool:
+def is_ndarray_convertable(obj: Any) -> bool:
     '''Returns True if the object is covertable to a builtin type in the same way a np.ndarray is
     
     Args:
-        obj (Union[np.ndarray, Any]): an object to test
+        obj (Any): an object to test
     Returns:
         bool: True if the object is covertable to a list as a np.ndarray is
     '''
@@ -208,6 +208,8 @@ def ndarray_to_builtin_object(obj: Any) -> Any:
 
     Args:
         obj (Any): An object
+    Raises:
+        ValueError: Raise a ValueError when obj is not ndarray convertable
     Returns:
         Any: The object converted to a builtin type like int, float or list
     '''
@@ -219,7 +221,7 @@ def ndarray_to_builtin_object(obj: Any) -> Any:
         else:
             return obj.tolist()
     else:
-        return obj
+        raise ValueError(f"{obj} is not ndarray convertable")
 
 
 def trained_needed(function: Callable) -> Callable:

--- a/gabarit/template_nlp/nlp_project/tests/test_utils.py
+++ b/gabarit/template_nlp/nlp_project/tests/test_utils.py
@@ -278,15 +278,19 @@ class UtilsTests(unittest.TestCase):
                 return self.args
         
         for obj, expected_result in (
-            (None, None),
-            ("some text", "some text"),
+            (None, ValueError),
+            ("some text", ValueError),
             (np.array(1), 1),
             (np.array(1.1), 1.1),
             (np.array([1, 2, 3], dtype=np.int64), [1, 2, 3]),
             (np.array([[1], [2], [3]], dtype=np.int64), [[1], [2], [3]]),
             (NumpyLike(1, 2, 3), (1, 2, 3)),
         ):
-            self.assertEqual(expected_result, utils.ndarray_to_builtin_object(obj))
+            if expected_result == ValueError:
+                with self.assertRaises(ValueError):
+                    utils.ndarray_to_builtin_object(obj)
+            else:
+                self.assertEqual(expected_result, utils.ndarray_to_builtin_object(obj))
 
 # TODO: test trained_needed & data_agnostic_str_to_list
 

--- a/gabarit/template_nlp/nlp_project/tests/test_utils.py
+++ b/gabarit/template_nlp/nlp_project/tests/test_utils.py
@@ -244,6 +244,49 @@ class UtilsTests(unittest.TestCase):
             with self.assertRaises(FileNotFoundError):
                 utils.find_folder_path('this/is/not/a/path', None)
 
+    def test11_is_ndarray_convertable(self):
+        '''Test of the function utils.is_ndarray_convertable'''
+        class NumpyLike:
+            def __init__(self, *args):
+                self.args = args
+                self.dtype = None
+            def astype(self, _):
+                return self
+            def tolist(self):
+                return self.args
+        
+        for obj, expected_result in (
+            (None, False),
+            ("some text", False),
+            (np.array(1), True),
+            (np.array(1.1), True),
+            (np.array([1, 2, 3], dtype=np.int64), True),
+            (np.array([[1], [2], [3]], dtype=np.int64), True),
+            (NumpyLike(1, 2, 3), True),
+        ):
+            self.assertEqual(expected_result, utils.is_ndarray_convertable(obj))
+
+    def test12_ndarray_to_builtin_object(self):
+        '''Test of the function utils.ndarray_to_builtin_object'''
+        class NumpyLike:
+            def __init__(self, *args):
+                self.args = args
+                self.dtype = None
+            def astype(self, _):
+                return self
+            def tolist(self):
+                return self.args
+        
+        for obj, expected_result in (
+            (None, None),
+            ("some text", "some text"),
+            (np.array(1), 1),
+            (np.array(1.1), 1.1),
+            (np.array([1, 2, 3], dtype=np.int64), [1, 2, 3]),
+            (np.array([[1], [2], [3]], dtype=np.int64), [[1], [2], [3]]),
+            (NumpyLike(1, 2, 3), (1, 2, 3)),
+        ):
+            self.assertEqual(expected_result, utils.ndarray_to_builtin_object(obj))
 
 # TODO: test trained_needed & data_agnostic_str_to_list
 

--- a/gabarit/template_num/num_project/package_name/utils.py
+++ b/gabarit/template_num/num_project/package_name/utils.py
@@ -165,6 +165,36 @@ def get_chunk_limits(x: Union[pd.DataFrame, pd.Series], chunksize: int = 10000) 
     return chunks_limits  # type: ignore
 
 
+def is_ndarray_convertable(obj: Union[np.ndarray, Any]) -> bool:
+    '''Returns True if the object is covertable to a builtin type in the same way a np.ndarray is
+    
+    Args:
+        obj (Union[np.ndarray, Any]): an object to test
+    Returns:
+        bool: True if the object is covertable to a list as a np.ndarray is
+    '''
+    return hasattr(obj, "dtype") and hasattr(obj, "astype") and hasattr(obj, "tolist")
+
+
+def ndarray_to_builtin_object(obj: np.ndarray) -> Any:
+    '''Transform a numpy.ndarray to a builtin type like int, float or list of ints
+
+    Args:
+        obj (np.ndarray): numpy.ndarray object
+    Returns:
+        Any: list containing builtin types like int or float
+    '''
+    if is_ndarray_convertable(obj):
+        if np.issubdtype(obj.dtype, np.integer):
+            return obj.astype(int).tolist()
+        elif np.issubdtype(obj.dtype, np.number):
+            return obj.astype(float).tolist()
+        else:
+            return obj.tolist()
+    else:
+        return obj
+
+
 def trained_needed(function: Callable) -> Callable:
     '''Decorator to ensure that a model has been trained.
 
@@ -311,12 +341,10 @@ def flatten(my_list: Iterable) -> Generator:
 class NpEncoder(json.JSONEncoder):
     '''JSON encoder to manage numpy objects'''
     def default(self, obj) -> Any:
-        if isinstance(obj, np.integer):
-            return int(obj)
-        elif isinstance(obj, np.floating):
-            return float(obj)
-        elif isinstance(obj, np.ndarray):
-            return obj.tolist()
+        if is_ndarray_convertable(obj):
+            return ndarray_to_builtin_object(obj)
+        elif isinstance(obj, set):
+            return list(obj)
         else:
             return super(NpEncoder, self).default(obj)
 

--- a/gabarit/template_num/num_project/package_name/utils.py
+++ b/gabarit/template_num/num_project/package_name/utils.py
@@ -165,24 +165,26 @@ def get_chunk_limits(x: Union[pd.DataFrame, pd.Series], chunksize: int = 10000) 
     return chunks_limits  # type: ignore
 
 
-def is_ndarray_convertable(obj: Union[np.ndarray, Any]) -> bool:
+def is_ndarray_convertable(obj: Any) -> bool:
     '''Returns True if the object is covertable to a builtin type in the same way a np.ndarray is
     
     Args:
-        obj (Union[np.ndarray, Any]): an object to test
+        obj (Any): an object to test
     Returns:
         bool: True if the object is covertable to a list as a np.ndarray is
     '''
     return hasattr(obj, "dtype") and hasattr(obj, "astype") and hasattr(obj, "tolist")
 
 
-def ndarray_to_builtin_object(obj: np.ndarray) -> Any:
-    '''Transform a numpy.ndarray to a builtin type like int, float or list of ints
+def ndarray_to_builtin_object(obj: Any) -> Any:
+    '''Transform a numpy.ndarray like object to a builtin type like int, float or list
 
     Args:
-        obj (np.ndarray): numpy.ndarray object
+        obj (Any): An object
+    Raises:
+        ValueError: Raise a ValueError when obj is not ndarray convertable
     Returns:
-        Any: list containing builtin types like int or float
+        Any: The object converted to a builtin type like int, float or list
     '''
     if is_ndarray_convertable(obj):
         if np.issubdtype(obj.dtype, np.integer):
@@ -192,7 +194,7 @@ def ndarray_to_builtin_object(obj: np.ndarray) -> Any:
         else:
             return obj.tolist()
     else:
-        return obj
+        raise ValueError(f"{obj} is not ndarray convertable")
 
 
 def trained_needed(function: Callable) -> Callable:

--- a/gabarit/template_num/num_project/tests/test_utils.py
+++ b/gabarit/template_num/num_project/tests/test_utils.py
@@ -315,15 +315,19 @@ class UtilsTests(unittest.TestCase):
                 return self.args
         
         for obj, expected_result in (
-            (None, None),
-            ("some text", "some text"),
+            (None, ValueError),
+            ("some text", ValueError),
             (np.array(1), 1),
             (np.array(1.1), 1.1),
             (np.array([1, 2, 3], dtype=np.int64), [1, 2, 3]),
             (np.array([[1], [2], [3]], dtype=np.int64), [[1], [2], [3]]),
             (NumpyLike(1, 2, 3), (1, 2, 3)),
         ):
-            self.assertEqual(expected_result, utils.ndarray_to_builtin_object(obj))
+            if expected_result == ValueError:
+                with self.assertRaises(ValueError):
+                    utils.ndarray_to_builtin_object(obj)
+            else:
+                self.assertEqual(expected_result, utils.ndarray_to_builtin_object(obj))
 
 
 # TODO: test trained_needed

--- a/gabarit/template_num/num_project/tests/test_utils.py
+++ b/gabarit/template_num/num_project/tests/test_utils.py
@@ -281,6 +281,50 @@ class UtilsTests(unittest.TestCase):
         flattened_list = list(utils.flatten(test_list))
         self.assertEqual(flattened_list, expected_result)
 
+    def test13_is_ndarray_convertable(self):
+        '''Test of the function utils.is_ndarray_convertable'''
+        class NumpyLike:
+            def __init__(self, *args):
+                self.args = args
+                self.dtype = None
+            def astype(self, _):
+                return self
+            def tolist(self):
+                return self.args
+        
+        for obj, expected_result in (
+            (None, False),
+            ("some text", False),
+            (np.array(1), True),
+            (np.array(1.1), True),
+            (np.array([1, 2, 3], dtype=np.int64), True),
+            (np.array([[1], [2], [3]], dtype=np.int64), True),
+            (NumpyLike(1, 2, 3), True),
+        ):
+            self.assertEqual(expected_result, utils.is_ndarray_convertable(obj))
+
+    def test14_ndarray_to_builtin_object(self):
+        '''Test of the function utils.ndarray_to_builtin_object'''
+        class NumpyLike:
+            def __init__(self, *args):
+                self.args = args
+                self.dtype = None
+            def astype(self, _):
+                return self
+            def tolist(self):
+                return self.args
+        
+        for obj, expected_result in (
+            (None, None),
+            ("some text", "some text"),
+            (np.array(1), 1),
+            (np.array(1.1), 1.1),
+            (np.array([1, 2, 3], dtype=np.int64), [1, 2, 3]),
+            (np.array([[1], [2], [3]], dtype=np.int64), [[1], [2], [3]]),
+            (NumpyLike(1, 2, 3), (1, 2, 3)),
+        ):
+            self.assertEqual(expected_result, utils.ndarray_to_builtin_object(obj))
+
 
 # TODO: test trained_needed
 

--- a/gabarit/template_vision/vision_project/package_name/utils.py
+++ b/gabarit/template_vision/vision_project/package_name/utils.py
@@ -394,6 +394,36 @@ def data_agnostic_str_to_list(function: Callable) -> Callable:
     return wrapper
 
 
+def is_ndarray_convertable(obj: Union[np.ndarray, Any]) -> bool:
+    '''Returns True if the object is covertable to a builtin type in the same way a np.ndarray is
+    
+    Args:
+        obj (Union[np.ndarray, Any]): an object to test
+    Returns:
+        bool: True if the object is covertable to a list as a np.ndarray is
+    '''
+    return hasattr(obj, "dtype") and hasattr(obj, "astype") and hasattr(obj, "tolist")
+
+
+def ndarray_to_builtin_object(obj: np.ndarray) -> Any:
+    '''Transform a numpy.ndarray to a builtin type like int, float or list of ints
+
+    Args:
+        obj (np.ndarray): numpy.ndarray object
+    Returns:
+        Any: list containing builtin types like int or float
+    '''
+    if is_ndarray_convertable(obj):
+        if np.issubdtype(obj.dtype, np.integer):
+            return obj.astype(int).tolist()
+        elif np.issubdtype(obj.dtype, np.number):
+            return obj.astype(float).tolist()
+        else:
+            return obj.tolist()
+    else:
+        return obj
+
+
 @data_agnostic_str_to_list
 def download_url(urls: list, output_path: str) -> None:
     '''Downloads an object from a list of URLs.
@@ -560,12 +590,10 @@ class DownloadProgressBar(tqdm):
 class NpEncoder(json.JSONEncoder):
     '''JSON encoder to manage numpy objects'''
     def default(self, obj) -> Any:
-        if isinstance(obj, np.integer):
-            return int(obj)
-        elif isinstance(obj, np.floating):
-            return float(obj)
-        elif isinstance(obj, np.ndarray):
-            return obj.tolist()
+        if is_ndarray_convertable(obj):
+            return ndarray_to_builtin_object(obj)
+        elif isinstance(obj, set):
+            return list(obj)
         else:
             return super(NpEncoder, self).default(obj)
 

--- a/gabarit/template_vision/vision_project/package_name/utils.py
+++ b/gabarit/template_vision/vision_project/package_name/utils.py
@@ -394,24 +394,26 @@ def data_agnostic_str_to_list(function: Callable) -> Callable:
     return wrapper
 
 
-def is_ndarray_convertable(obj: Union[np.ndarray, Any]) -> bool:
+def is_ndarray_convertable(obj: Any) -> bool:
     '''Returns True if the object is covertable to a builtin type in the same way a np.ndarray is
     
     Args:
-        obj (Union[np.ndarray, Any]): an object to test
+        obj (Any): an object to test
     Returns:
         bool: True if the object is covertable to a list as a np.ndarray is
     '''
     return hasattr(obj, "dtype") and hasattr(obj, "astype") and hasattr(obj, "tolist")
 
 
-def ndarray_to_builtin_object(obj: np.ndarray) -> Any:
-    '''Transform a numpy.ndarray to a builtin type like int, float or list of ints
+def ndarray_to_builtin_object(obj: Any) -> Any:
+    '''Transform a numpy.ndarray like object to a builtin type like int, float or list
 
     Args:
-        obj (np.ndarray): numpy.ndarray object
+        obj (Any): An object
+    Raises:
+        ValueError: Raise a ValueError when obj is not ndarray convertable
     Returns:
-        Any: list containing builtin types like int or float
+        Any: The object converted to a builtin type like int, float or list
     '''
     if is_ndarray_convertable(obj):
         if np.issubdtype(obj.dtype, np.integer):
@@ -421,7 +423,7 @@ def ndarray_to_builtin_object(obj: np.ndarray) -> Any:
         else:
             return obj.tolist()
     else:
-        return obj
+        raise ValueError(f"{obj} is not ndarray convertable")
 
 
 @data_agnostic_str_to_list

--- a/gabarit/template_vision/vision_project/tests/test_utils.py
+++ b/gabarit/template_vision/vision_project/tests/test_utils.py
@@ -292,6 +292,49 @@ class UtilsTests(unittest.TestCase):
             with self.assertRaises(FileNotFoundError):
                 utils.find_folder_path('this/is/not/a/path', None)
 
+    def test09_is_ndarray_convertable(self):
+        '''Test of the function utils.is_ndarray_convertable'''
+        class NumpyLike:
+            def __init__(self, *args):
+                self.args = args
+                self.dtype = None
+            def astype(self, _):
+                return self
+            def tolist(self):
+                return self.args
+        
+        for obj, expected_result in (
+            (None, False),
+            ("some text", False),
+            (np.array(1), True),
+            (np.array(1.1), True),
+            (np.array([1, 2, 3], dtype=np.int64), True),
+            (np.array([[1], [2], [3]], dtype=np.int64), True),
+            (NumpyLike(1, 2, 3), True),
+        ):
+            self.assertEqual(expected_result, utils.is_ndarray_convertable(obj))
+
+    def test10_ndarray_to_builtin_object(self):
+        '''Test of the function utils.ndarray_to_builtin_object'''
+        class NumpyLike:
+            def __init__(self, *args):
+                self.args = args
+                self.dtype = None
+            def astype(self, _):
+                return self
+            def tolist(self):
+                return self.args
+        
+        for obj, expected_result in (
+            (None, None),
+            ("some text", "some text"),
+            (np.array(1), 1),
+            (np.array(1.1), 1.1),
+            (np.array([1, 2, 3], dtype=np.int64), [1, 2, 3]),
+            (np.array([[1], [2], [3]], dtype=np.int64), [[1], [2], [3]]),
+            (NumpyLike(1, 2, 3), (1, 2, 3)),
+        ):
+            self.assertEqual(expected_result, utils.ndarray_to_builtin_object(obj))
 
 # Perform tests
 if __name__ == '__main__':

--- a/gabarit/template_vision/vision_project/tests/test_utils.py
+++ b/gabarit/template_vision/vision_project/tests/test_utils.py
@@ -326,15 +326,19 @@ class UtilsTests(unittest.TestCase):
                 return self.args
         
         for obj, expected_result in (
-            (None, None),
-            ("some text", "some text"),
+            (None, ValueError),
+            ("some text", ValueError),
             (np.array(1), 1),
             (np.array(1.1), 1.1),
             (np.array([1, 2, 3], dtype=np.int64), [1, 2, 3]),
             (np.array([[1], [2], [3]], dtype=np.int64), [[1], [2], [3]]),
             (NumpyLike(1, 2, 3), (1, 2, 3)),
         ):
-            self.assertEqual(expected_result, utils.ndarray_to_builtin_object(obj))
+            if expected_result == ValueError:
+                with self.assertRaises(ValueError):
+                    utils.ndarray_to_builtin_object(obj)
+            else:
+                self.assertEqual(expected_result, utils.ndarray_to_builtin_object(obj))
 
 # Perform tests
 if __name__ == '__main__':


### PR DESCRIPTION
## ✒️ Context

Model Explainer (LIME) does not work with the Streamlit demonstrator because numpy objects are not handled by LimExplainer.

- What kind of change does this PR introduce ?

  - [x] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧱 Description of Changes

- Add two new utils functions to test if an object can be converted to builtin types as a numpy ndarray is
- Update NpEncoder to use the new utils functions (this makes the JSONEncoder way more handy for handling numpy objects)
-Use the new utils functions in LimeExplainer to handle numpy objects as argument

  - [x] This is a change for the NLP template
  - [x] This is a change for the NUM template
  - [x] This is a change for the VISION template
  - [ ] This is a change for the API template
  - [ ] This changes how templates are generated (i.e. a Jinja change)

## 🩺 Testing

- Add tests to all templates to test the two new utils fuctions

  - [ ] This change does not need new tests
  - [x] Added/Updated unit tests
  - [ ] Added/Updated functionals tests (i.e. e2e)

## 🔗 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #104 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the GNU AFFERO GENERAL PUBLIC LICENSE.
