### PR TITLE
feat: add owerwrite arg to all template scripts

### DIFF
--- a/gabarit/template_nlp/nlp_project/package_name-scripts/1_preprocess_data.py
+++ b/gabarit/template_nlp/nlp_project/package_name-scripts/1_preprocess_data.py
@@ -35,7 +35,7 @@ logger = logging.getLogger('{{package_name}}.1_preprocess_data')
 
 
 def main(filenames: List[str], preprocessing: Union[str, None], input_col: Union[str, int],
-         sep: str = '{{default_sep}}', encoding: str = '{{default_encoding}}') -> None:
+         sep: str = '{{default_sep}}', encoding: str = '{{default_encoding}}', overwrite: bool = False) -> None:
     '''Preprocesses some datasets
 
     Args:
@@ -45,6 +45,7 @@ def main(filenames: List[str], preprocessing: Union[str, None], input_col: Union
     Kwargs:
         sep (str): Separator to use with the .csv files
         encoding (str): Encoding to use with the .csv files
+        overwrite (bool): Whether to allow overwriting
     Raises:
         FileNotFoundError: If a given file does not exist in {{package_name}}-data
     '''
@@ -102,7 +103,11 @@ def main(filenames: List[str], preprocessing: Union[str, None], input_col: Union
             # First line is a metadata with the name of the preprocess
             basename = Path(filename).stem
             dataset_preprocessed_path = os.path.join(data_path, f'{basename}_{preprocess_str}.csv')
-            utils.to_csv(df, dataset_preprocessed_path, first_line=f'#{preprocess_str}', sep='{{default_sep}}', encoding='{{default_encoding}}')
+
+            if os.path.exists(dataset_preprocessed_path) and not overwrite:
+                logger.info(f"{dataset_preprocessed_path} already exists. Pass.")
+            else:
+                utils.to_csv(df, dataset_preprocessed_path, first_line=f'#{preprocess_str}', sep='{{default_sep}}', encoding='{{default_encoding}}')
 
 
 if __name__ == '__main__':
@@ -112,5 +117,6 @@ if __name__ == '__main__':
     parser.add_argument('--input_col', default=None, required=True, help='Column to be preprocessed')
     parser.add_argument('--sep', default='{{default_sep}}', help="Separator to use with the .csv files.")
     parser.add_argument('--encoding', default="{{default_encoding}}", help="Encoding to use with the .csv files.")
+    parser.add_argument('--overwrite', action='store_true', help="Whether to allow overwriting")
     args = parser.parse_args()
-    main(filenames=args.filenames, preprocessing=args.preprocessing, input_col=args.input_col, sep=args.sep, encoding=args.encoding)
+    main(filenames=args.filenames, preprocessing=args.preprocessing, input_col=args.input_col, sep=args.sep, encoding=args.encoding, overwrite=args.overwrite)

--- a/gabarit/template_nlp/nlp_project/package_name-scripts/utils/0_create_samples.py
+++ b/gabarit/template_nlp/nlp_project/package_name-scripts/utils/0_create_samples.py
@@ -32,7 +32,7 @@ from {{package_name}} import utils
 logger = logging.getLogger('{{package_name}}.0_create_samples')
 
 
-def main(filenames: List[str], n_samples: int = 100, sep: str = '{{default_sep}}', encoding: str = '{{default_encoding}}') -> None:
+def main(filenames: List[str], n_samples: int = 100, sep: str = '{{default_sep}}', encoding: str = '{{default_encoding}}', overwrite: bool = False) -> None:
     '''Extracts data subsets from a list of files
 
     Args:
@@ -41,6 +41,7 @@ def main(filenames: List[str], n_samples: int = 100, sep: str = '{{default_sep}}
         n_samples (int): Number of samples to extract
         sep (str): Separator to use with the .csv files
         encoding (str): Encoding to use with the .csv files
+        overwrite (bool): Whether to allow overwriting
     Raises:
         FileNotFoundError: If a given file does not exist in {{package_name}}-data
     '''
@@ -63,7 +64,7 @@ def main(filenames: List[str], n_samples: int = 100, sep: str = '{{default_sep}}
         new_file_name = f"{base_file_name}_{n_samples}_samples.csv"
         new_path = os.path.join(data_path, new_file_name)
         # We do not trigger an error if the file exists
-        if os.path.exists(new_path):
+        if os.path.exists(new_path) and not overwrite:
             logger.info(f"{new_path} already exists. Pass.")
             continue
 
@@ -83,5 +84,6 @@ if __name__ == '__main__':
     parser.add_argument('-n', '--n_samples', type=int, default=100, help="Number of samples to extract")
     parser.add_argument('--sep', default='{{default_sep}}', help="Separator to use with the .csv files")
     parser.add_argument('--encoding', default="{{default_encoding}}", help="Encoding to use with the .csv files")
+    parser.add_argument('--overwrite', action='store_true', help="Whether to allow overwriting")
     args = parser.parse_args()
-    main(filenames=args.filenames, n_samples=args.n_samples, sep=args.sep, encoding=args.encoding)
+    main(filenames=args.filenames, n_samples=args.n_samples, sep=args.sep, encoding=args.encoding, overwrite=args.overwrite)

--- a/gabarit/template_nlp/nlp_project/package_name-scripts/utils/0_get_embedding_dict.py
+++ b/gabarit/template_nlp/nlp_project/package_name-scripts/utils/0_get_embedding_dict.py
@@ -32,7 +32,7 @@ from {{package_name}} import utils
 logger = logging.getLogger('{{package_name}}.0_get_embedding_dict')
 
 
-def main(filename: str, encoding: str = '{{default_encoding}}') -> None:
+def main(filename: str, encoding: str = '{{default_encoding}}', overwrite: bool = False) -> None:
     '''Creates an embedding matrix from .vec files (fasttext format)
 
     Those files can be downloaded here (text files): https://fasttext.cc/docs/en/crawl-vectors.html
@@ -41,6 +41,7 @@ def main(filename: str, encoding: str = '{{default_encoding}}') -> None:
         filename (str): A .vec file name (actually a path relative to {{package_name}}-data)
     Kwargs:
         encoding (str): Encoding to use with the .vec file
+        overwrite (bool): Whether to allow overwriting
     Raises:
         FileNotFoundError: If the file does not exist in {{package_name}}-data
     '''
@@ -59,6 +60,10 @@ def main(filename: str, encoding: str = '{{default_encoding}}') -> None:
 
     # Save
     file_path = os.path.join(data_path, '.'.join(filename.split('.')[:-1]) + '.pkl')
+
+    if os.path.exists(file_path) and not overwrite:
+        raise FileExistsError(f"{file_path} already exists. This error can be bypassed with the argument --overwrite.")
+        
     with open(file_path, 'wb') as f:
         pickle.dump(embedding_indexes, f, pickle.HIGHEST_PROTOCOL)
 
@@ -67,5 +72,6 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-f', '--filename', required=True, help='A .vec file name (actually a path relative to {{package_name}}-data)')
     parser.add_argument('--encoding', default="utf-8", help="Encoding to use with the .vec file.")
+    parser.add_argument('--overwrite', action='store_true', help="Whether to allow overwriting")
     args = parser.parse_args()
-    main(filename=args.filename, encoding=args.encoding)
+    main(filename=args.filename, encoding=args.encoding, overwrite=args.overwrite)

--- a/gabarit/template_nlp/nlp_project/package_name-scripts/utils/0_merge_files.py
+++ b/gabarit/template_nlp/nlp_project/package_name-scripts/utils/0_merge_files.py
@@ -60,7 +60,7 @@ def main(filenames: List[str], cols: Union[List[Union[str, int]], None] = None, 
     # Manage new file
     output_path = os.path.join(data_path, output)
     if os.path.isfile(output_path) and not overwrite_dataset:
-        raise FileNotFoundError(f"The file {output_path} already exists.")
+        raise FileExistsError(f"The file {output_path} already exists.")
 
     # Init. dataframe
     df = pd.DataFrame(columns=cols)

--- a/gabarit/template_num/num_project/package_name-scripts/utils/0_create_samples.py
+++ b/gabarit/template_num/num_project/package_name-scripts/utils/0_create_samples.py
@@ -32,7 +32,7 @@ from {{package_name}} import utils
 logger = logging.getLogger('{{package_name}}.0_create_samples')
 
 
-def main(filenames: List[str], n_samples: int = 100, sep: str = '{{default_sep}}', encoding: str = '{{default_encoding}}') -> None:
+def main(filenames: List[str], n_samples: int = 100, sep: str = '{{default_sep}}', encoding: str = '{{default_encoding}}', overwrite: bool = False) -> None:
     '''Extracts data subsets from a list of files
 
     Args:
@@ -41,6 +41,7 @@ def main(filenames: List[str], n_samples: int = 100, sep: str = '{{default_sep}}
         n_samples (int): Number of samples to extract
         sep (str): Separator to use with the .csv files
         encoding (str): Encoding to use with the .csv files
+        overwrite (bool): Whether to allow overwriting
     Raises:
         FileNotFoundError: If a given file does not exist in {{package_name}}-data
     '''
@@ -63,7 +64,7 @@ def main(filenames: List[str], n_samples: int = 100, sep: str = '{{default_sep}}
         new_file_name = f"{base_file_name}_{n_samples}_samples.csv"
         new_path = os.path.join(data_path, new_file_name)
         # We do not trigger an error if the file exists
-        if os.path.exists(new_path):
+        if os.path.exists(new_path) and not overwrite:
             logger.info(f"{new_path} already exists. Pass.")
             continue
 
@@ -83,5 +84,6 @@ if __name__ == '__main__':
     parser.add_argument('-n', '--n_samples', type=int, default=100, help="Number of samples to extract")
     parser.add_argument('--sep', default='{{default_sep}}', help="Separator to use with the .csv files")
     parser.add_argument('--encoding', default="{{default_encoding}}", help="Encoding to use with the .csv files")
+    parser.add_argument('--overwrite', action='store_true', help="Whether to allow overwriting")
     args = parser.parse_args()
-    main(filenames=args.filenames, n_samples=args.n_samples, sep=args.sep, encoding=args.encoding)
+    main(filenames=args.filenames, n_samples=args.n_samples, sep=args.sep, encoding=args.encoding, overwrite=args.overwrite)

--- a/gabarit/template_num/num_project/package_name-scripts/utils/0_merge_files.py
+++ b/gabarit/template_num/num_project/package_name-scripts/utils/0_merge_files.py
@@ -60,7 +60,7 @@ def main(filenames: List[str], cols: Union[List[Union[str, int]], None] = None, 
     # Manage new file
     output_path = os.path.join(data_path, output)
     if os.path.isfile(output_path) and not overwrite_dataset:
-        raise FileNotFoundError(f"The file {output_path} already exists.")
+        raise FileExistsError(f"The file {output_path} already exists.")
 
     # Init. dataframe
     df = pd.DataFrame(columns=cols)

--- a/gabarit/template_vision/vision_project/package_name-scripts/1_preprocess_data.py
+++ b/gabarit/template_vision/vision_project/package_name-scripts/1_preprocess_data.py
@@ -39,7 +39,7 @@ from {{package_name}}.preprocessing import preprocess
 logger = logging.getLogger('{{package_name}}.1_preprocess_data')
 
 
-def main(directories: List[str], preprocessing: Union[str, None], sep: str = '{{default_sep}}', encoding: str = '{{default_encoding}}') -> None:
+def main(directories: List[str], preprocessing: Union[str, None], sep: str = '{{default_sep}}', encoding: str = '{{default_encoding}}', overwrite: bool = False) -> None:
     '''Preprocesses some datasets
 
     Args:
@@ -48,6 +48,7 @@ def main(directories: List[str], preprocessing: Union[str, None], sep: str = '{{
     Kwargs:
         sep (str): Separator to use with the metadata file - if exists
         encoding (str): Encoding to use with the metadata file - if exists
+        overwrite (bool): Whether to allow overwriting
     Raises:
         FileNotFoundError: If a given directory does not exist in {{package_name}}-data
         NotADirectoryError: If a given path is not a directory
@@ -126,8 +127,12 @@ def main(directories: List[str], preprocessing: Union[str, None], sep: str = '{{
             # We start by creating a new directory for the preprocessed images
             new_directory = os.path.join(data_path, f"{directory}_{preprocess_str}")
             if os.path.exists(new_directory):
-                shutil.rmtree(new_directory)
-            os.makedirs(new_directory)
+                if overwrite:
+                    shutil.rmtree(new_directory)
+                    os.makedirs(new_directory)
+                else:
+                    logger.info(f"{new_directory} already exists. Pass.")
+                    continue
 
             # Process by chunks of 100s to avoid memory issues
             new_path_list = []
@@ -189,5 +194,6 @@ if __name__ == '__main__':
     parser.add_argument('-p', '--preprocessing', default=None, help='Preprocessing to be applied. All preprocessings are applied if None.')
     parser.add_argument('--sep', default='{{default_sep}}', help='Separator to use with the metadata file - if exists.')
     parser.add_argument('--encoding', default="{{default_encoding}}", help='Encoding to use with the metadata file - if exists.')
+    parser.add_argument('--overwrite', action='store_true', help="Whether to allow overwriting")
     args = parser.parse_args()
-    main(directories=args.directories, preprocessing=args.preprocessing, sep=args.sep, encoding=args.encoding)
+    main(directories=args.directories, preprocessing=args.preprocessing, sep=args.sep, encoding=args.encoding, overwrite=args.overwrite)

--- a/gabarit/template_vision/vision_project/package_name-scripts/utils/0_create_samples.py
+++ b/gabarit/template_vision/vision_project/package_name-scripts/utils/0_create_samples.py
@@ -35,7 +35,7 @@ from {{package_name}} import utils
 logger = logging.getLogger('{{package_name}}.0_create_samples')
 
 
-def main(directories: List[str], n_samples: int = 100, sep: str = '{{default_sep}}', encoding: str = '{{default_encoding}}'):
+def main(directories: List[str], n_samples: int = 100, sep: str = '{{default_sep}}', encoding: str = '{{default_encoding}}', overwrite: bool = False):
     '''Extracts data subsets from a list of directories
 
     Args:
@@ -44,6 +44,7 @@ def main(directories: List[str], n_samples: int = 100, sep: str = '{{default_sep
         n_samples (int): Number of samples to extract
         sep (str): Separator to use with the metadata file - if exists
         encoding (str): Encoding to use with the metadata file - if exists
+        overwrite (bool): Whether to allow overwriting
     Raises:
         FileNotFoundError: If a given directory does not exist in {{package_name}}-data
         NotADirectoryError: If a given path is not a directory
@@ -68,8 +69,11 @@ def main(directories: List[str], n_samples: int = 100, sep: str = '{{default_sep
         new_directory = os.path.join(data_path, f"{directory}_{n_samples}_samples")
         # We do not trigger an error if the directory exists
         if os.path.exists(new_directory):
-            logger.info(f"{new_directory} already exists. Pass.")
-            continue
+            if overwrite:
+                shutil.rmtree(new_directory)
+            else:
+                logger.info(f"{new_directory} already exists. Pass.")
+                continue
         os.makedirs(new_directory)
 
         # load data
@@ -122,5 +126,6 @@ if __name__ == '__main__':
     parser.add_argument('-n', '--n_samples', type=int, default=100, help="Number of samples to extract")
     parser.add_argument('--sep', default='{{default_sep}}', help="Separator to use with the .csv files")
     parser.add_argument('--encoding', default="{{default_encoding}}", help="Encoding to use with the .csv files")
+    parser.add_argument('--overwrite', action='store_true', help="Whether to allow overwriting")
     args = parser.parse_args()
-    main(directories=args.directories, n_samples=args.n_samples, sep=args.sep, encoding=args.encoding)
+    main(directories=args.directories, n_samples=args.n_samples, sep=args.sep, encoding=args.encoding, overwrite=args.overwrite)


### PR DESCRIPTION
## ✒️ Context

0_split_train_valid_test.py has an argument --overwrite to allow overwriting datasets.
Others scripts such as 0_create_samples.py could also benefit from it.

- What kind of change does this PR introduce ?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧱 Description of Changes

- Add overwrite argument to all relevent scripts 

  - [x] This is a change for the NLP template
  - [x] This is a change for the NUM template
  - [x] This is a change for the VISION template
  - [ ] This is a change for the API template
  - [ ] This changes how templates are generated (i.e. a Jinja change)

## 🩺 Testing

Tested locally

## 🔗 References

- **Issue**: Closes #71

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the GNU AFFERO GENERAL PUBLIC LICENSE.
