### PR TITLE
Feature/52 predict functions

### DIFF
--- a/gabarit/template_nlp/nlp_project/package_name/models_training/utils_models.py
+++ b/gabarit/template_nlp/nlp_project/package_name/models_training/utils_models.py
@@ -309,11 +309,11 @@ def load_model(model_dir: str, is_path: bool = False) -> Tuple[Any, dict]:
     return model, configs
 
 
-def predict(content: str, model, model_conf: dict, **kwargs) -> list:
+def predict(content: Union[str, list], model, model_conf: dict, **kwargs) -> list:
     '''Gets predictions of a model on a content
 
     Args:
-        content (str): New content to be predicted
+        content (Union[str, list]): New content to be predicted
         model (ModelClass): Model to use
         model_conf (dict): Model configurations
     Returns:
@@ -339,11 +339,11 @@ def predict(content: str, model, model_conf: dict, **kwargs) -> list:
     return model.inverse_transform(predictions)
 
 
-def predict_with_proba(content: str, model, model_conf: dict) -> Union[Tuple[List[str], List[float]], Tuple[List[tuple], List[tuple]]]:
+def predict_with_proba(content: Union[str, list], model, model_conf: dict) -> Union[Tuple[List[str], List[float]], Tuple[List[tuple], List[tuple]]]:
     '''Gets predictions of a model on a content, with probabilities
 
     Args:
-        content (str): New content to be predicted
+        content (Union[str, list]): New content to be predicted
         model (ModelClass): Model to use
         model_conf (dict): Model configurations
     Returns:

--- a/gabarit/template_nlp/nlp_project/package_name/models_training/utils_models.py
+++ b/gabarit/template_nlp/nlp_project/package_name/models_training/utils_models.py
@@ -339,7 +339,7 @@ def predict(content: str, model, model_conf: dict, **kwargs) -> list:
     return model.inverse_transform(predictions)
 
 
-def predict_with_proba(content: str, model, model_conf: dict) -> Tuple[Union[List[str], List[tuple]], Union[List[float], List[tuple]]]:
+def predict_with_proba(content: str, model, model_conf: dict) -> Union[Tuple[List[str], List[float]], Tuple[List[tuple], List[tuple]]]:
     '''Gets predictions of a model on a content, with probabilities
 
     Args:

--- a/gabarit/template_nlp/nlp_project/tests/test_utils_models.py
+++ b/gabarit/template_nlp/nlp_project/tests/test_utils_models.py
@@ -313,8 +313,8 @@ class UtilsModelsTests(unittest.TestCase):
         model.fit(x_train, y_train_mono)
         model.save()
         model, model_conf = utils_models.load_model('test_model3')
-        self.assertEqual(utils_models.predict('Ceci est un test', model, model_conf), 'test')
-        self.assertEqual(utils_models.predict('Test "deux" !', model, model_conf), 'deux')
+        self.assertEqual(utils_models.predict('Ceci est un test', model, model_conf), ['test'])
+        self.assertEqual(utils_models.predict('Test "deux" !', model, model_conf), ['deux'])
         remove_dir(model_dir)
 
         # Nominal case - multi-labels
@@ -325,8 +325,8 @@ class UtilsModelsTests(unittest.TestCase):
         model.fit(x_train, y_train_multi)
         model.save()
         model, model_conf = utils_models.load_model('test_model3')
-        self.assertEqual(utils_models.predict('Ceci est un test', model, model_conf), ('test',))
-        self.assertEqual(utils_models.predict('Toto "deux" !', model, model_conf), ('toto',))
+        self.assertEqual(utils_models.predict('Ceci est un test', model, model_conf), [('test',)])
+        self.assertEqual(utils_models.predict('Toto "deux" !', model, model_conf), [('toto',)])
         remove_dir(model_dir)
 
     def test10_predict_with_proba(self):
@@ -347,11 +347,11 @@ class UtilsModelsTests(unittest.TestCase):
         model.save()
         model, model_conf = utils_models.load_model('test_model4')
         pred, proba = utils_models.predict_with_proba('Ceci est un test', model, model_conf)
-        self.assertEqual(pred, 'test')
-        self.assertEqual(proba, 1.0) # 1.0 because svm
+        self.assertEqual(pred, ['test'])
+        self.assertEqual(proba, [1.0]) # 1.0 because svm
         pred, proba = utils_models.predict_with_proba('Test "deux" !', model, model_conf)
-        self.assertEqual(pred, 'deux')
-        self.assertEqual(proba, 1.0) # 1.0 because svm
+        self.assertEqual(pred, ['deux'])
+        self.assertEqual(proba, [1.0]) # 1.0 because svm
         remove_dir(model_dir)
 
         # Nominal case - multi-labels
@@ -363,11 +363,11 @@ class UtilsModelsTests(unittest.TestCase):
         model.save()
         model, model_conf = utils_models.load_model('test_model4')
         pred, proba = utils_models.predict_with_proba('Ceci est un test', model, model_conf)
-        self.assertEqual(pred, ('test',))
-        self.assertEqual(proba, (1.0,)) # 1.0 because svm
+        self.assertEqual(pred, [('test',)])
+        self.assertEqual(proba, [(1.0,)]) # 1.0 because svm
         pred, proba = utils_models.predict_with_proba('Toto "deux" !', model, model_conf)
-        self.assertEqual(pred, ('toto',))
-        self.assertEqual(proba, (1.0,)) # 1.0 because svm
+        self.assertEqual(pred, [('toto',)])
+        self.assertEqual(proba, [(1.0,)]) # 1.0 because svm
         remove_dir(model_dir)
 
     def test11_search_hp_cv(self):

--- a/gabarit/template_nlp/nlp_project/tests/test_utils_models.py
+++ b/gabarit/template_nlp/nlp_project/tests/test_utils_models.py
@@ -327,6 +327,7 @@ class UtilsModelsTests(unittest.TestCase):
         model, model_conf = utils_models.load_model('test_model3')
         self.assertEqual(utils_models.predict('Ceci est un test', model, model_conf), [('test',)])
         self.assertEqual(utils_models.predict('Toto "deux" !', model, model_conf), [('toto',)])
+        self.assertEqual(utils_models.predict(['Ceci est un test', 'Toto test "deux" !'], model, model_conf), [('test',), ('test', 'toto')])
         remove_dir(model_dir)
 
     def test10_predict_with_proba(self):
@@ -368,6 +369,9 @@ class UtilsModelsTests(unittest.TestCase):
         pred, proba = utils_models.predict_with_proba('Toto "deux" !', model, model_conf)
         self.assertEqual(pred, [('toto',)])
         self.assertEqual(proba, [(1.0,)]) # 1.0 because svm
+        pred, proba = utils_models.predict_with_proba(['Ceci est un test', 'Toto test "deux" !'], model, model_conf)
+        self.assertEqual(pred, [('test',), ('test', 'toto')])
+        self.assertEqual(proba, [(1.0,), (1.0, 1.0)]) # 1.0 because svm
         remove_dir(model_dir)
 
     def test11_search_hp_cv(self):

--- a/gabarit/template_num/num_project/package_name/models_training/utils_models.py
+++ b/gabarit/template_num/num_project/package_name/models_training/utils_models.py
@@ -42,7 +42,7 @@ import numpy as np
 import pandas as pd
 import dill as pickle
 from datetime import datetime
-from typing import Union, Tuple, Callable, Any
+from typing import Union, Tuple, Callable, Any, List
 
 from sklearn.pipeline import Pipeline
 from sklearn.compose import ColumnTransformer
@@ -348,7 +348,7 @@ def apply_pipeline(df: pd.DataFrame, preprocess_pipeline: ColumnTransformer) -> 
     return preprocessed_df
 
 
-def predict(content: pd.DataFrame, model, **kwargs) -> Union[float, str, tuple, list]:
+def predict(content: pd.DataFrame, model, **kwargs) -> list:
     '''Gets predictions of a model on a dataset
 
     Args:
@@ -377,16 +377,11 @@ def predict(content: pd.DataFrame, model, **kwargs) -> Union[float, str, tuple, 
     # Inverse transform (needed for classification)
     predictions = model.inverse_transform(predictions)
 
-    # Return only first element if dataframe has one row
-    # TODO: Shouldn't we return the full prediction even if one row ?
-    if content.shape[0] == 1:
-        predictions = predictions[0]
-
     # Return
     return predictions
 
 
-def predict_with_proba(content: pd.DataFrame, model) -> Tuple[Union[str, tuple, list], Union[float, tuple, list]]:
+def predict_with_proba(content: pd.DataFrame, model) -> Union[Tuple[List[str], List[float]], Tuple[List[tuple], List[tuple]]]:
     '''Gets probabilities predictions of a model on a dataset
 
     Args:
@@ -396,13 +391,11 @@ def predict_with_proba(content: pd.DataFrame, model) -> Tuple[Union[str, tuple, 
         ValueError: If the model type is not classifier
     Returns:
         MONO-LABEL CLASSIFICATION:
-            str: prediction
-            float: probability
+            List[str]: predictions
+            List[float]: probabilities
         MULTI-LABELS CLASSIFICATION:
-            tuple: predictions
-            tuple: probabilities
-
-        If several elements -> list
+            List[tuple]: predictions
+            List[tuple]: probabilities
     '''
     # Regressions
     if not model.model_type == 'classifier':
@@ -425,11 +418,6 @@ def predict_with_proba(content: pd.DataFrame, model) -> Tuple[Union[str, tuple, 
     else:
         prediction = [tuple(np.array(model.list_classes).compress(indicators)) for indicators in predictions]
         proba = [tuple(np.array(probas[i]).compress(indicators)) for i, indicators in enumerate(predictions)]
-
-    # Return only first element if dataframe has one row
-    if content.shape[0] == 1:
-        prediction = prediction[0]
-        proba = proba[0]
 
     # Return prediction & proba
     return prediction, proba

--- a/gabarit/template_num/num_project/tests/test_utils_models.py
+++ b/gabarit/template_num/num_project/tests/test_utils_models.py
@@ -494,10 +494,10 @@ class UtilsModelsTests(unittest.TestCase):
         y_train_regression = pd.Series([-10, -10, -10, 10, 10, 10] * 10)
         y_test_classification = [0, 1, 0, 1, 0, 1]
         y_test_classification_multi = [('test',), ('toto',), ('test',), ('toto',), ('test',), ('toto',)]
-        y_test_1_classification_solo = 0
-        y_test_2_classification_solo = 1
-        y_test_1_classification_multi_solo = ('test',)
-        y_test_2_classification_multi_solo = ('toto',)
+        y_test_1_classification_solo = [0]
+        y_test_2_classification_solo = [1]
+        y_test_1_classification_multi_solo = [('test',)]
+        y_test_2_classification_multi_solo = [('toto',)]
         model_dir = os.path.join(utils.get_models_path(), 'test_model')
         model_name = 'test_model_name'
 
@@ -574,7 +574,7 @@ class UtilsModelsTests(unittest.TestCase):
         model, model_conf = utils_models.load_model(model_dir='test_model')
         # Check just the type, regression is complicated...
         self.assertEqual(type(utils_models.predict(x_test_1, model)), list)
-        self.assertTrue(isinstance(utils_models.predict(x_test_1_solo, model), (np.floating, float)))
+        self.assertTrue(isinstance(utils_models.predict(x_test_1_solo, model), list))
         remove_dir(model_dir)
 
         ################
@@ -590,7 +590,7 @@ class UtilsModelsTests(unittest.TestCase):
         model, model_conf = utils_models.load_model(model_dir='test_model')
         # Check just the type, regression is complicated...
         self.assertEqual(type(utils_models.predict(x_test_2, model)), list)
-        self.assertTrue(isinstance(utils_models.predict(x_test_2_solo, model), (np.floating, float)))
+        self.assertTrue(isinstance(utils_models.predict(x_test_2_solo, model), list))
         remove_dir(model_dir)
 
 
@@ -609,10 +609,10 @@ class UtilsModelsTests(unittest.TestCase):
         y_train_regression = pd.Series([-10, -10, -10, 10, 10, 10] * 10)
         y_test_classification = [0, 1, 0, 1, 0, 1]
         y_test_classification_multi = [('test',), ('toto',), ('test',), ('toto',), ('test',), ('toto',)]
-        y_test_1_classification_solo = 0
-        y_test_2_classification_solo = 1
-        y_test_1_classification_multi_solo = ('test',)
-        y_test_2_classification_multi_solo = ('toto',)
+        y_test_1_classification_solo = [0]
+        y_test_2_classification_solo = [1]
+        y_test_1_classification_multi_solo = [('test',)]
+        y_test_2_classification_multi_solo = [('toto',)]
         model_dir = os.path.join(utils.get_models_path(), 'test_model')
         model_name = 'test_model_name'
 
@@ -633,7 +633,7 @@ class UtilsModelsTests(unittest.TestCase):
         self.assertEqual(sum([round(p) for p in proba]), len(y_test_classification))
         pred, proba = utils_models.predict_with_proba(x_test_1_solo, model)
         self.assertEqual(pred, y_test_1_classification_solo)
-        self.assertTrue(proba >= 0.5)
+        self.assertTrue(proba[0] >= 0.5)
         remove_dir(model_dir)
 
         ################
@@ -653,7 +653,7 @@ class UtilsModelsTests(unittest.TestCase):
         self.assertEqual(sum([round(p) for p in proba]), len(y_test_classification))
         pred, proba = utils_models.predict_with_proba(x_test_2_solo, model)
         self.assertEqual(pred, y_test_2_classification_solo)
-        self.assertTrue(proba >= 0.5)
+        self.assertTrue(proba[0] >= 0.5)
         remove_dir(model_dir)
 
         ################
@@ -673,7 +673,7 @@ class UtilsModelsTests(unittest.TestCase):
         self.assertEqual(sum([round(p[0]) for p in proba]), sum([len(_) for _ in y_test_classification_multi]))
         pred, proba = utils_models.predict_with_proba(x_test_1_solo, model)
         self.assertEqual(pred, y_test_1_classification_multi_solo)
-        self.assertTrue(proba[0] >= 0.5)
+        self.assertTrue(proba[0][0] >= 0.5)
         remove_dir(model_dir)
 
         ################
@@ -693,7 +693,7 @@ class UtilsModelsTests(unittest.TestCase):
         self.assertEqual(sum([round(p[0]) for p in proba]), sum([len(_) for _ in y_test_classification_multi]))
         pred, proba = utils_models.predict_with_proba(x_test_2_solo, model)
         self.assertEqual(pred, y_test_2_classification_multi_solo)
-        self.assertTrue(proba[0] >= 0.5)
+        self.assertTrue(proba[0][0] >= 0.5)
         remove_dir(model_dir)
 
         ################

--- a/gabarit/template_vision/vision_project/package_name/models_training/utils_models.py
+++ b/gabarit/template_vision/vision_project/package_name/models_training/utils_models.py
@@ -327,18 +327,14 @@ def predict(data_input: Union[str, List[str], np.ndarray, pd.DataFrame], model, 
     ##############################################
     # Return result
     ##############################################
-
-    # TODO: Shouldn't we return the full prediction even if one element ?
-    # Return one element if only one input, else return all
     if return_proba:
-        return probas[0] if len(probas) == 1 else probas
+        return probas
     else:
-        predictions = model.inverse_transform(predictions)
-        return predictions[0] if len(predictions) == 1 else predictions
+        return model.inverse_transform(predictions)
 
 
 def predict_with_proba(data_input: Union[str, List[str], np.ndarray, pd.DataFrame], model,
-                       model_conf: dict) -> Tuple[Union[str, List[str]], Union[float, List[float]]]:
+                       model_conf: dict) -> Tuple[List[str], List[float]]:
     '''Gets probabilities predictions of a model on a dataset
 
     Args:
@@ -354,10 +350,7 @@ def predict_with_proba(data_input: Union[str, List[str], np.ndarray, pd.DataFram
         NotImplementedError: If model is object detection task
         ValueError : If predict does not return an np.ndarray
     Returns:
-        str: prediction
-        float: probability
-
-        If several elements -> list
+        Union[List[str], List[float]]: predictions, probabilities
     '''
     if model.model_type == 'object_detector':
         raise NotImplementedError("`predict_with_proba` is not yet implemented for object detection task")
@@ -370,15 +363,9 @@ def predict_with_proba(data_input: Union[str, List[str], np.ndarray, pd.DataFram
         raise ValueError("Internal error - probas should be an np.ndarray.")
 
     # Manage cases with only one element
-    if len(probas.shape) == 1:
-        predictions = model.get_classes_from_proba(np.expand_dims(probas, 0))
-        predictions = model.inverse_transform(predictions)[0]
-        max_probas = max(probas)
-    # Several elements
-    else:
-        predictions = model.get_classes_from_proba(probas)
-        predictions = model.inverse_transform(predictions)
-        max_probas = list(probas.max(axis=1))
+    predictions = model.get_classes_from_proba(probas)
+    predictions = model.inverse_transform(predictions)
+    max_probas = list(probas.max(axis=1))
 
     # Return
     return predictions, max_probas

--- a/gabarit/template_vision/vision_project/package_name/models_training/utils_models.py
+++ b/gabarit/template_vision/vision_project/package_name/models_training/utils_models.py
@@ -207,7 +207,7 @@ def load_model(model_dir: str, is_path: bool = False) -> Tuple[Any, dict]:
 
 
 def predict(data_input: Union[str, List[str], np.ndarray, pd.DataFrame], model, model_conf: dict,
-            return_proba: bool = False, **kwargs) -> Union[str, List[str], np.ndarray]:
+            return_proba: bool = False, **kwargs) -> Union[List[str], List[float]]:
     '''Gets predictions of a model on images
 
     Args:
@@ -230,9 +230,9 @@ def predict(data_input: Union[str, List[str], np.ndarray, pd.DataFrame], model, 
         ValueError: If the input DataFrame does not contains a 'file_path' column (input type == pd.DataFrame)
         ValueError: If the input type is not a valid type option
     Returns:
-        str, List[str], np.ndarray: predictions or probabilities
-            - If return_proba -> np.ndarray (shape depends on number of inputs)
-            - Else str or list<str> (depends on number of inputs)
+        List[str], List[float]: predictions or probabilities
+            - If return_proba -> List[float]
+            - Else List[str]
     '''
     # TODO
     # TODO

--- a/gabarit/template_vision/vision_project/package_name/models_training/utils_models.py
+++ b/gabarit/template_vision/vision_project/package_name/models_training/utils_models.py
@@ -207,7 +207,7 @@ def load_model(model_dir: str, is_path: bool = False) -> Tuple[Any, dict]:
 
 
 def predict(data_input: Union[str, List[str], np.ndarray, pd.DataFrame], model, model_conf: dict,
-            return_proba: bool = False, **kwargs) -> Union[List[str], List[float]]:
+            return_proba: bool = False, **kwargs) -> Union[List[str], np.ndarray]:
     '''Gets predictions of a model on images
 
     Args:
@@ -230,8 +230,8 @@ def predict(data_input: Union[str, List[str], np.ndarray, pd.DataFrame], model, 
         ValueError: If the input DataFrame does not contains a 'file_path' column (input type == pd.DataFrame)
         ValueError: If the input type is not a valid type option
     Returns:
-        List[str], List[float]: predictions or probabilities
-            - If return_proba -> List[float]
+        List[str], np.ndarray: predictions or probabilities
+            - If return_proba -> np.ndarray
             - Else List[str]
     '''
     # TODO

--- a/gabarit/template_vision/vision_project/tests/test_utils_models.py
+++ b/gabarit/template_vision/vision_project/tests/test_utils_models.py
@@ -230,14 +230,14 @@ class UtilsModelsTests(unittest.TestCase):
         model, model_conf = utils_models.load_model(model_dir=model_name)
         self.assertEqual(utils_models.predict(df_train_mono, model, model_conf), y_classes)  # DataFrame
         self.assertEqual(utils_models.predict(file_paths, model, model_conf), y_classes)  # Liste fichiers
-        self.assertEqual(utils_models.predict(file_paths[0], model, model_conf), y_classes[0])  # Chemin fichier
+        self.assertEqual(utils_models.predict(file_paths[0], model, model_conf)[0], y_classes[0])  # Chemin fichier
         self.assertEqual(utils_models.predict(np_images_rgb, model, model_conf), y_classes[1:]) # np.ndarray 'RGB'
-        self.assertEqual(utils_models.predict(np_images_rgb[0], model, model_conf), y_classes[1]) # np.ndarray 'RGB' - 1 seule image
+        self.assertEqual(utils_models.predict(np_images_rgb[0], model, model_conf)[0], y_classes[1]) # np.ndarray 'RGB' - 1 seule image
         np.testing.assert_almost_equal(utils_models.predict(df_train_mono, model, model_conf, return_proba=True), probas, 3)  # DataFrame
         np.testing.assert_almost_equal(utils_models.predict(file_paths, model, model_conf, return_proba=True), probas, 3)  # Liste fichiers
-        np.testing.assert_almost_equal(utils_models.predict(file_paths[0], model, model_conf, return_proba=True), probas[0], 3)  # Chemin fichier
+        np.testing.assert_almost_equal(utils_models.predict(file_paths[0], model, model_conf, return_proba=True)[0], probas[0], 3)  # Chemin fichier
         np.testing.assert_almost_equal(utils_models.predict(np_images_rgb, model, model_conf, return_proba=True), probas[1:], 3) # np.ndarray 'RGB'
-        np.testing.assert_almost_equal(utils_models.predict(np_images_rgb[0], model, model_conf, return_proba=True), probas[1], 3) # np.ndarray 'RGB' - 1 seule image
+        np.testing.assert_almost_equal(utils_models.predict(np_images_rgb[0], model, model_conf, return_proba=True)[0], probas[1], 3) # np.ndarray 'RGB' - 1 seule image
         remove_dir(model_dir)
 
 
@@ -256,14 +256,14 @@ class UtilsModelsTests(unittest.TestCase):
         model, model_conf = utils_models.load_model(model_dir=model_name)
         self.assertEqual(utils_models.predict(df_train_multi, model, model_conf), y_classes)  # DataFrame
         self.assertEqual(utils_models.predict(file_paths, model, model_conf), y_classes)  # Liste fichiers
-        self.assertEqual(utils_models.predict(file_paths[0], model, model_conf), y_classes[0])  # Chemin fichier
+        self.assertEqual(utils_models.predict(file_paths[0], model, model_conf)[0], y_classes[0])  # Chemin fichier
         self.assertEqual(utils_models.predict(np_images_rgba, model, model_conf), y_classes[1:]) # np.ndarray 'RGBA'
-        self.assertEqual(utils_models.predict(np_images_rgba[0], model, model_conf), y_classes[1]) # np.ndarray 'RGB' - 1 seule image
+        self.assertEqual(utils_models.predict(np_images_rgba[0], model, model_conf)[0], y_classes[1]) # np.ndarray 'RGB' - 1 seule image
         np.testing.assert_almost_equal(utils_models.predict(df_train_multi, model, model_conf, return_proba=True), probas, 3)  # DataFrame
         np.testing.assert_almost_equal(utils_models.predict(file_paths, model, model_conf, return_proba=True), probas, 3)  # Liste fichiers
-        np.testing.assert_almost_equal(utils_models.predict(file_paths[0], model, model_conf, return_proba=True), probas[0], 3)  # Chemin fichier
+        np.testing.assert_almost_equal(utils_models.predict(file_paths[0], model, model_conf, return_proba=True)[0], probas[0], 3)  # Chemin fichier
         np.testing.assert_almost_equal(utils_models.predict(np_images_rgba, model, model_conf, return_proba=True), probas[1:], 3) # np.ndarray 'RGBA'
-        np.testing.assert_almost_equal(utils_models.predict(np_images_rgba[0], model, model_conf, return_proba=True), probas[1], 3) # np.ndarray 'RGB' - 1 seule image
+        np.testing.assert_almost_equal(utils_models.predict(np_images_rgba[0], model, model_conf, return_proba=True)[0], probas[1], 3) # np.ndarray 'RGB' - 1 seule image
         remove_dir(model_dir)
 
 
@@ -333,14 +333,14 @@ class UtilsModelsTests(unittest.TestCase):
         model, model_conf = utils_models.load_model(model_dir=model_name)
         self.assertEqual(utils_models.predict_with_proba(df_train_mono, model, model_conf)[0], y_classes)  # DataFrame
         self.assertEqual(utils_models.predict_with_proba(file_paths, model, model_conf)[0], y_classes)  # Liste fichiers
-        self.assertEqual(utils_models.predict_with_proba(file_paths[0], model, model_conf)[0], y_classes[0])  # Chemin fichier
+        self.assertEqual(utils_models.predict_with_proba(file_paths[0], model, model_conf)[0][0], y_classes[0])  # Chemin fichier
         self.assertEqual(utils_models.predict_with_proba(np_images_rgb, model, model_conf)[0], y_classes[1:]) # np.ndarray 'RGB'
-        self.assertEqual(utils_models.predict_with_proba(np_images_rgb[0], model, model_conf)[0], y_classes[1]) # np.ndarray 'RGB' - 1 seule image
+        self.assertEqual(utils_models.predict_with_proba(np_images_rgb[0], model, model_conf)[0][0], y_classes[1]) # np.ndarray 'RGB' - 1 seule image
         np.testing.assert_almost_equal(utils_models.predict_with_proba(df_train_mono, model, model_conf)[1], max_probas, 3)  # DataFrame
         np.testing.assert_almost_equal(utils_models.predict_with_proba(file_paths, model, model_conf)[1], max_probas, 3)  # Liste fichiers
-        np.testing.assert_almost_equal(utils_models.predict_with_proba(file_paths[0], model, model_conf)[1], max_probas[0], 3)  # Chemin fichier
+        np.testing.assert_almost_equal(utils_models.predict_with_proba(file_paths[0], model, model_conf)[1][0], max_probas[0], 3)  # Chemin fichier
         np.testing.assert_almost_equal(utils_models.predict_with_proba(np_images_rgb, model, model_conf)[1], max_probas[1:], 3) # np.ndarray 'RGB'
-        np.testing.assert_almost_equal(utils_models.predict_with_proba(np_images_rgb[0], model, model_conf)[1], max_probas[1], 3) # np.ndarray 'RGB' - 1 seule image
+        np.testing.assert_almost_equal(utils_models.predict_with_proba(np_images_rgb[0], model, model_conf)[1][0], max_probas[1], 3) # np.ndarray 'RGB' - 1 seule image
         remove_dir(model_dir)
 
 
@@ -360,14 +360,14 @@ class UtilsModelsTests(unittest.TestCase):
         model, model_conf = utils_models.load_model(model_dir=model_name)
         self.assertEqual(utils_models.predict_with_proba(df_train_multi, model, model_conf)[0], y_classes)  # DataFrame
         self.assertEqual(utils_models.predict_with_proba(file_paths, model, model_conf)[0], y_classes)  # Liste fichiers
-        self.assertEqual(utils_models.predict_with_proba(file_paths[0], model, model_conf)[0], y_classes[0])  # Chemin fichier
+        self.assertEqual(utils_models.predict_with_proba(file_paths[0], model, model_conf)[0][0], y_classes[0])  # Chemin fichier
         self.assertEqual(utils_models.predict_with_proba(np_images_rgba, model, model_conf)[0], y_classes[1:]) # np.ndarray 'RGBA'
-        self.assertEqual(utils_models.predict_with_proba(np_images_rgba[0], model, model_conf)[0], y_classes[1]) # np.ndarray 'RGB' - 1 seule image
+        self.assertEqual(utils_models.predict_with_proba(np_images_rgba[0], model, model_conf)[0][0], y_classes[1]) # np.ndarray 'RGB' - 1 seule image
         np.testing.assert_almost_equal(utils_models.predict_with_proba(df_train_multi, model, model_conf)[1], max_probas, 3)  # DataFrame
         np.testing.assert_almost_equal(utils_models.predict_with_proba(file_paths, model, model_conf)[1], max_probas, 3)  # Liste fichiers
-        np.testing.assert_almost_equal(utils_models.predict_with_proba(file_paths[0], model, model_conf)[1], max_probas[0], 3)  # Chemin fichier
+        np.testing.assert_almost_equal(utils_models.predict_with_proba(file_paths[0], model, model_conf)[1][0], max_probas[0], 3)  # Chemin fichier
         np.testing.assert_almost_equal(utils_models.predict_with_proba(np_images_rgba, model, model_conf)[1], max_probas[1:], 3) # np.ndarray 'RGBA'
-        np.testing.assert_almost_equal(utils_models.predict_with_proba(np_images_rgba[0], model, model_conf)[1], max_probas[1], 3) # np.ndarray 'RGB' - 1 seule image
+        np.testing.assert_almost_equal(utils_models.predict_with_proba(np_images_rgba[0], model, model_conf)[1][0], max_probas[1], 3) # np.ndarray 'RGB' - 1 seule image
         remove_dir(model_dir)
 
 


### PR DESCRIPTION
## ✒️ Context

`utils_models.predict` outputs are not consistent between templates.
Make all `utils_models.predict` functions handle multiple inputs and return a list.

- What kind of change does this PR introduce ?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧱 Description of Changes

- _Add bullet points summarizing your changes here_

  - [x] This is a change for the NLP template
  - [x] This is a change for the NUM template
  - [x] This is a change for the VISION template
  - [ ] This is a change for the API template
  - [ ] This changes how templates are generated (i.e. a Jinja change)

## 🩺 Testing

- Change all tests/test_utils_models.py to take changes into account

  - [ ] This change does not need new tests
  - [x] Added/Updated unit tests
  - [ ] Added/Updated functionals tests (i.e. e2e)

## 🔗 References

- **Issue**: Closes #37
- **Issue**: Closes #52

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the GNU AFFERO GENERAL PUBLIC LICENSE.
