### PR TITLE
fix: specify plateform for detectron2 requirement

### DIFF
--- a/gabarit/template_vision/vision_project/package_name/models_training/object_detectors/model_detectron_faster_rcnn.py
+++ b/gabarit/template_vision/vision_project/package_name/models_training/object_detectors/model_detectron_faster_rcnn.py
@@ -43,20 +43,31 @@ from sklearn.model_selection import train_test_split
 
 # Imports detectron
 import torch
-from detectron2.utils import comm
-from detectron2.structures import BoxMode
-from detectron2.data import transforms as T
-from detectron2.engine.hooks import HookBase
-from detectron2.config import get_cfg, CfgNode
-from detectron2.utils.file_io import PathManager
-from detectron2.utils.visualizer import Visualizer
-from detectron2.engine import hooks as module_hooks
-from detectron2.engine import DefaultTrainer, DefaultPredictor
-from detectron2.evaluation import COCOEvaluator, verify_results
-from detectron2.utils.events import EventWriter, get_event_storage, EventStorage
-from detectron2.data import (DatasetCatalog, MetadataCatalog, Metadata, detection_utils,
-                             build_detection_train_loader, build_detection_test_loader,
-                             DatasetMapper)
+
+try:
+    from detectron2.utils import comm
+    from detectron2.structures import BoxMode
+    from detectron2.data import transforms as T
+    from detectron2.engine.hooks import HookBase
+    from detectron2.config import get_cfg, CfgNode
+    from detectron2.utils.file_io import PathManager
+    from detectron2.utils.visualizer import Visualizer
+    from detectron2.engine import hooks as module_hooks
+    from detectron2.engine import DefaultTrainer, DefaultPredictor
+    from detectron2.evaluation import COCOEvaluator, verify_results
+    from detectron2.utils.events import EventWriter, get_event_storage, EventStorage
+    from detectron2.data import (DatasetCatalog, MetadataCatalog, Metadata, detection_utils,
+                                build_detection_train_loader, build_detection_test_loader,
+                                DatasetMapper)
+except ImportError:
+    if os.name == "nt":
+        logging.getLogger(__name__).warning(
+            "On windows, there are no pre-built for detectron2. "
+            "You must first install torch and then install detectron2 manually: "
+            "pip install git+https://github.com/facebookresearch/detectron2.git@v0.6+cpu "
+            "(you might need to update Visual Studio C++)"
+        )
+    raise
 
 # Import package utils
 from ... import utils

--- a/gabarit/template_vision/vision_project/requirements.txt
+++ b/gabarit/template_vision/vision_project/requirements.txt
@@ -18,7 +18,7 @@ torchvision==0.9.1+cpu
 # Detectron2
 # If GPU with cuda 11.1 : replace +cpu by +cu111
 --find-links https://dl.fbaipublicfiles.com/detectron2/wheels/cpu/torch1.8/index.html
-detectron2==0.6+cpu
+detectron2==0.6+cpu; platform_system != "Windows"
 # Warning, on windows, there are no pre-built for detectron2
 # You must first install torch and then install detectron2 manually:
 # pip install git+https://github.com/facebookresearch/detectron2.git@v0.6+cpu


### PR DESCRIPTION
## ✒️ Context

Detectron2 installation is not supported on windows.
One should install it manually, and there is no documentation for it.

- What kind of change does this PR introduce ?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧱 Description of Changes

- Specify `platform_system != "Windows"` for detectron2 in `requirements.txt`
- Add a warning in `model_detectron_faster_rcnn.py`

  - [ ] This is a change for the NLP template
  - [ ] This is a change for the NUM template
  - [x] This is a change for the VISION template
  - [ ] This is a change for the API template
  - [ ] This changes how templates are generated (i.e. a Jinja change)

## 🩺 Testing

I tried to `pip install` a `requirements.txt` file containing the new instruction : `detectron2 ; platform_system != "Windows"`
  
`pip` displays a nice warning : `Ignoring detectron2: markers 'platform_system != "Windows"' don't match your environment`


## 🔗 References

- **Issue**: Closes #50 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the GNU AFFERO GENERAL PUBLIC LICENSE.
