### PR TITLE
fix: remove black, flake8 and isort from makefiles

### DIFF
--- a/gabarit/template_nlp/nlp_project/Makefile
+++ b/gabarit/template_nlp/nlp_project/Makefile
@@ -65,30 +65,3 @@ ifndef VIRTUAL_ENV
 	$(error Python virtual environment not activated !)
 endif
 	nosetests -c nose_setup_coverage.cfg tests --exe # https://stackoverflow.com/questions/1457104/nose-unable-to-find-tests-in-ubuntu
-
-####################################################
-# Code quality
-####################################################
-
-quality: black isort flake8 ## Launch the code quality tools
-
-black: ## Code formatter
-ifndef VIRTUAL_ENV
-	$(error Python virtual environment not activated !)
-endif
-	pip install black;\
-	black -l 140 -t py38 -S .
-
-isort: ## Utility to automatically sort imports
-ifndef VIRTUAL_ENV
-	$(error Python virtual environment not activated !)
-endif
-	pip install isort;\
-	isort --skip venv_{{package_name}} -rc .
-
-flake8: ## Guide Enforcement tool
-ifndef VIRTUAL_ENV
-	$(error Python virtual environment not activated !)
-endif
-	pip install flake8;\
-	flake8 --exclude=venv_{{package_name}} . # add "|| exit 0" to avoid error

--- a/gabarit/template_num/num_project/Makefile
+++ b/gabarit/template_num/num_project/Makefile
@@ -64,30 +64,3 @@ ifndef VIRTUAL_ENV
 	$(error Python virtual environment not activated !)
 endif
 	nosetests -c nose_setup_coverage.cfg tests --exe # https://stackoverflow.com/questions/1457104/nose-unable-to-find-tests-in-ubuntu
-
-####################################################
-# Code quality
-####################################################
-
-quality: black isort flake8 ## Launch the code quality tools
-
-black: ## Code formatter
-ifndef VIRTUAL_ENV
-	$(error Python virtual environment not activated !)
-endif
-	pip install black;\
-	black -l 140 -t py38 -S .
-
-isort: ## Utility to automatically sort imports
-ifndef VIRTUAL_ENV
-	$(error Python virtual environment not activated !)
-endif
-	pip install isort;\
-	isort --skip venv_{{package_name}} -rc .
-
-flake8: ## Guide Enforcement tool
-ifndef VIRTUAL_ENV
-	$(error Python virtual environment not activated !)
-endif
-	pip install flake8;\
-	flake8 --exclude=venv_{{package_name}} . # add "|| exit 0" to avoid error

--- a/gabarit/template_vision/vision_project/Makefile
+++ b/gabarit/template_vision/vision_project/Makefile
@@ -64,30 +64,3 @@ ifndef VIRTUAL_ENV
 	$(error Python virtual environment not activated !)
 endif
 	nosetests -c nose_setup_coverage.cfg tests --exe # https://stackoverflow.com/questions/1457104/nose-unable-to-find-tests-in-ubuntu
-
-####################################################
-# Code quality
-####################################################
-
-quality: black isort flake8 ## Launch the code quality tools
-
-black: ## Code formatter
-ifndef VIRTUAL_ENV
-	$(error Python virtual environment not activated !)
-endif
-	pip install black;\
-	black -l 140 -t py38 -S .
-
-isort: ## Utility to automatically sort imports
-ifndef VIRTUAL_ENV
-	$(error Python virtual environment not activated !)
-endif
-	pip install isort;\
-	isort --skip venv_{{package_name}} -rc .
-
-flake8: ## Guide Enforcement tool
-ifndef VIRTUAL_ENV
-	$(error Python virtual environment not activated !)
-endif
-	pip install flake8;\
-	flake8 --exclude=venv_{{package_name}} . # add "|| exit 0" to avoid error


### PR DESCRIPTION
## ✒️ Context

The `quality` command of NLP, NUM and VISION makefiles is not used and will probably break or be inconvenient for the user. We should remove it.

- What kind of change does this PR introduce ?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧱 Description of Changes

- _Add bullet points summarizing your changes here_

  - [x] This is a change for the NLP template
  - [x] This is a change for the NUM template
  - [x] This is a change for the VISION template
  - [ ] This is a change for the API template
  - [ ] This changes how templates are generated (i.e. a Jinja change)

## 🔗 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #39 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the GNU AFFERO GENERAL PUBLIC LICENSE.
