### PR TITLE
fix: remove return type annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ![NLP tests](https://github.com/OSS-Pole-Emploi/gabarit/actions/workflows/nlp_build_tests.yaml/badge.svg)
 ![NUM tests](https://github.com/OSS-Pole-Emploi/gabarit/actions/workflows/num_build_tests.yaml/badge.svg)
 ![VISION tests](https://github.com/OSS-Pole-Emploi/gabarit/actions/workflows/vision_build_tests.yaml/badge.svg)
+![API tests](https://github.com/OSS-Pole-Emploi/gabarit/actions/workflows/api_build_tests.yaml/badge.svg)
 ![NLP wheel](https://github.com/OSS-Pole-Emploi/gabarit/actions/workflows/nlp_wheel.yaml/badge.svg)
 ![NUM wheel](https://github.com/OSS-Pole-Emploi/gabarit/actions/workflows/num_wheel.yaml/badge.svg)
 ![VISION wheel](https://github.com/OSS-Pole-Emploi/gabarit/actions/workflows/vision_wheel.yaml/badge.svg)
@@ -78,7 +79,7 @@ Therefore, these frameworks act as project templates that you can use to generat
 
 Three IA Frameworks are available:
 
-- **NLP**, to tackle classification use cases on textual data
+- **NLP** to tackle classification use cases on textual data
 
 	-	Relies on the Words'n fun module for the preprocessing requirements
 
@@ -108,6 +109,7 @@ Three IA Frameworks are available:
 		- Multi Classes / Mono Label classification
 		- Area of interest detection
 
+And one [**API Framework**](/gabarit/template_api). It can be used to expose a gabarit model or a model of your own.
 
 These frameworks have been developped to manage different subjects but share a common structure and a common philosophy. Once a project made using a framework is in production, any other project can be sent into production following the same process.
 Along with these frameworks, an API template has been developped and should soon be open sourced as well. With it, you can expose framework made models in no time !

--- a/gabarit/template_api/api_project/package_name/routers/functional.py
+++ b/gabarit/template_api/api_project/package_name/routers/functional.py
@@ -30,8 +30,11 @@ router = APIRouter()
 
 
 # This function is async since it uses starlette Request
+# There is no return type annotation because starting from FastAPI 0.89, type annotations are
+# interpreted as response_model and response_model must be valid pydantic. Since we use here a
+# startlette.Response we remove return annotation (cf. https://fastapi.tiangolo.com/release-notes/#0890)
 @router.post("/predict")
-async def predict(request: Request) -> NumpyJSONResponse:
+async def predict(request: Request):
     """Predict route that exposes your model
 
     This function is using starlette Request object instead of pydantic since we can not
@@ -57,8 +60,12 @@ async def predict(request: Request) -> NumpyJSONResponse:
 
     return NumpyJSONResponse(prediction)
 
+# This function is async since it uses starlette Request
+# There is no return type annotation because starting from FastAPI 0.89, type annotations are
+# interpreted as response_model and response_model must be valid pydantic. Since we use here a
+# startlette.Response we remove return annotation (cf. https://fastapi.tiangolo.com/release-notes/#0890)
 @router.post("/explain")
-async def explain(request: Request) -> Union[Response, HTMLResponse, NumpyJSONResponse]:
+async def explain(request: Request):
     """Explain route that expose a model explainer in charge of model explicability
 
     This function is using starlette Request object instead of pydantic since we can not


### PR DESCRIPTION

## ✒️ Context

Starting from [FastAPI 0.89](https://fastapi.tiangolo.com/release-notes/#0890), return type annotations are used for response_model declaration.
Since we are using generic starlette responses for predict and explain routes in the template (in order to be response agnostic by default) we can no longer use a type annotation or a FastAPIError: Invalid args for response field! will be raised.

- What kind of change does this PR introduce ?

  - Bugfix

## 🧱 Description of Changes

- Remove return type annotations for `predict` and `explain` routes in template API
  - This is a change for the API template

## 🩺 Testing

It should fix tests which are currently failing 

## 🔗 References

- **Issue**: Closes #113

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the GNU AFFERO GENERAL PUBLIC LICENSE.
