### PR TITLE
refacto: remove depracted events and add lifespan

### DIFF
--- a/gabarit/template_api/api_project/package_name/application.py
+++ b/gabarit/template_api/api_project/package_name/application.py
@@ -21,7 +21,7 @@ from starlette_prometheus import metrics, PrometheusMiddleware
 
 from .core.config import settings
 from .routers import main_routeur
-from .core.event_handlers import start_app_handler, stop_app_handler
+from .core.resources import lifespan
 
 
 def declare_application() -> FastAPI:
@@ -33,11 +33,8 @@ def declare_application() -> FastAPI:
     app = FastAPI(
         title=f"REST API form {settings.app_name}",
         description=f"Use {settings.app_name} thanks to FastAPI",
+        lifespan=lifespan
     )
-
-    # Load the model on startup
-    app.add_event_handler("startup", start_app_handler(app))
-    app.add_event_handler("shutdown", stop_app_handler(app))
 
     # Add PrometheusMiddleware
     app.add_middleware(PrometheusMiddleware)

--- a/gabarit/template_api/api_project/package_name/routers/functional.py
+++ b/gabarit/template_api/api_project/package_name/routers/functional.py
@@ -24,6 +24,7 @@ from starlette.responses import HTMLResponse, Response
 
 from ..model.model_base import Model
 from .schemas.functional import NumpyJSONResponse
+from ..core.resources import RESOURCES, RESOURCE_MODEL
 
 # Functional router
 router = APIRouter()
@@ -51,7 +52,7 @@ async def predict(request: Request):
     responses schemas thanks to pydantic or have a look at the FastAPI documentation :
     https://fastapi.tiangolo.com/tutorial/response-model/
     """
-    model: Model = request.app.state.model
+    model: Model = RESOURCES.get(RESOURCE_MODEL)
 
     body = await request.body()
     body = json.loads(body) if body else {}
@@ -85,7 +86,7 @@ async def explain(request: Request):
     If there is not explainer or the explainer does not implement explain_as_json or explain_as_html
     we return a 501 HTTP error : https://developer.mozilla.org/fr/docs/Web/HTTP/Status/501
     """
-    model: Model = request.app.state.model
+    model: Model = RESOURCES.get(RESOURCE_MODEL)
 
     body = await request.body()
     body = json.loads(body) if body else {}

--- a/gabarit/template_api/api_project/package_name/routers/technical.py
+++ b/gabarit/template_api/api_project/package_name/routers/technical.py
@@ -16,9 +16,9 @@
 
 
 from fastapi import APIRouter
-from starlette.requests import Request
 
 from ..core.config import settings
+from ..core.resources import RESOURCES, RESOURCE_MODEL
 from ..model.model_base import Model
 from .schemas.technical import ReponseInformation, ReponseLiveness, ReponseReadiness
 
@@ -44,11 +44,9 @@ async def get_liveness() -> ReponseLiveness:
     name="readiness",
     tags=["technical"],
 )
-async def get_readiness(request: Request) -> ReponseReadiness:
+async def get_readiness() -> ReponseReadiness:
     """Readiness probe for k8s"""
-    model: Model = (
-        request.app.state.model if hasattr(request.app.state, "model") else None
-    )
+    model: Model = RESOURCES.get(RESOURCE_MODEL)
 
     if model and model.is_model_loaded():
         return ReponseReadiness(ready="ok")
@@ -62,9 +60,9 @@ async def get_readiness(request: Request) -> ReponseReadiness:
     name="information",
     tags=["technical"],
 )
-async def info(request: Request) -> ReponseInformation:
+async def info() -> ReponseInformation:
     """Rest resource for info"""
-    model: Model = request.app.state.model
+    model: Model = RESOURCES.get(RESOURCE_MODEL)
 
     return ReponseInformation(
         application=settings.app_name,

--- a/gabarit/template_api/api_project/pyproject.toml
+++ b/gabarit/template_api/api_project/pyproject.toml
@@ -7,7 +7,7 @@ name = "{{package_name}}"
 version = "0.0.1"
 requires-python = ">=3.7,<4.0"
 dependencies = [
-    "fastapi>=0.87,<1.0",
+    "fastapi>=0.94.1,<1.0",
     "uvicorn[standard]>=0.20,<1.0",
     "starlette-prometheus>=0.9,<1.0",
     "numpy>=1.19,<2.0",
@@ -43,7 +43,7 @@ filterwarnings = [
 ]
 
 [project.scripts]
-download-model = "{{package_name}}.core.event_handlers:Model.download_model"
+download-model = "{{package_name}}.core.resources:Model.download_model"
 
 [tool.isort]
 profile = "black"

--- a/gabarit/template_api/api_project/tests/conftest.py
+++ b/gabarit/template_api/api_project/tests/conftest.py
@@ -71,12 +71,13 @@ def test_complete_client(monkeypatch) -> TestClient:
     """Complete TestClient that do run startup and shutdown events to load
     the model
     """
-    from {{package_name}}.application import app
-    from {{package_name}}.core import event_handlers
+    from {{package_name}}.core import resources
     from {{package_name}}.model.model_base import Model
 
     # Use base model for tests
-    monkeypatch.setattr(event_handlers, "Model", Model)
+    monkeypatch.setattr(resources, "Model", Model)
 
+    from {{package_name}}.application import app
+    
     with TestClient(app) as client:
         yield client

--- a/gabarit/template_api/api_project/tests/test_routers_functionnal.py
+++ b/gabarit/template_api/api_project/tests/test_routers_functionnal.py
@@ -18,6 +18,7 @@
 import pytest
 from fastapi.testclient import TestClient
 from .create_test_model import TestExplainer
+from template_api.core.resources import RESOURCES, RESOURCE_MODEL
 
 
 def test_predict(test_complete_client: TestClient):
@@ -49,7 +50,7 @@ def test_explain(test_complete_client: TestClient):
     assert response.status_code == 501
 
     # Now add a TestExplainer to test the explanations
-    test_complete_client.app.state.model._model_explainer = TestExplainer()
+    RESOURCES[RESOURCE_MODEL]._model_explainer = TestExplainer()
 
     # HTML response
     response = test_complete_client.post(


### PR DESCRIPTION
## ✒️ Context


[Startup and Shutdown events are now deprecated](https://fastapi.tiangolo.com/advanced/events/#alternative-events-deprecated) (FastAPI >= 0.93).

The [new recommanded way to instantiate a machine learning model](https://fastapi.tiangolo.com/advanced/events/#use-case) in FastApi is with lifespan events.

- What kind of change does this PR introduce ?

  - [ ] Bugfix
  - [ ] Feature
  - [x] Refactoring
  - [ ] Other, please describe:

## 🧱 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a change for the NLP template
  - [ ] This is a change for the NUM template
  - [ ] This is a change for the VISION template
  - [x] This is a change for the API template
  - [ ] This changes how templates are generated (i.e. a Jinja change)

## 🩺 Testing

- _Add bullet points summarizing your changes here_

  - [ ] This change does not need new tests
  - [x] Added/Updated unit tests
  - [ ] Added/Updated functionals tests (i.e. e2e)

## 🔗 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #144 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the GNU AFFERO GENERAL PUBLIC LICENSE.
