### PR TITLE
[169] Fix API template by setting fastapi <0.100

### DIFF
--- a/gabarit/template_api/api_project/pyproject.toml
+++ b/gabarit/template_api/api_project/pyproject.toml
@@ -7,7 +7,7 @@ name = "{{package_name}}"
 version = "0.0.1"
 requires-python = ">=3.7,<4.0"
 dependencies = [
-    "fastapi>=0.94.1,<1.0",
+    "fastapi>=0.94.1,<0.100",
     "uvicorn[standard]>=0.20,<1.0",
     "starlette-prometheus>=0.9,<1.0",
     "numpy>=1.19,<2.0",


### PR DESCRIPTION
<!--
Before contributing :

⚠️ Any contribution that is more than a few lines of code must be stated on the corresponding issue. If there is no issue for it yet, please create it first.

This ensure that :

  1. Two people aren't working on the same thing
	2. This is something Gabarit's maintainers believe should be implemented/fixed
  3. Your time is well spent :)

-->

## ✒️ Context

Test issues due to an unsupported migration of pydantic package

- What kind of change does this PR introduce ?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧱 Description of Changes

- Quick fix by setting fastapi version to be <0.100 instead of <1.0
- More discussion needs to be done before effectively applying the migration
- Adresses (but does not close) issue #169 

  - [ ] This is a change for the NLP template
  - [ ] This is a change for the NUM template
  - [ ] This is a change for the VISION template
  - [x] This is a change for the API template
  - [ ] This changes how templates are generated (i.e. a Jinja change)

## 🩺 Testing

  - [x] This change does not need new tests
  - [ ] Added/Updated unit tests
  - [ ] Added/Updated functionals tests (i.e. e2e)

## 🔗 References

- **Issue**: Closes #XXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the GNU AFFERO GENERAL PUBLIC LICENSE.
