### PR TITLE
Changed the workflows to free space

### DIFF
--- a/.github/workflows/nlp_wheel.yaml
+++ b/.github/workflows/nlp_wheel.yaml
@@ -1,4 +1,4 @@
-name: Wheel setup - NLP
+name: Wheel setup - NLP < 3.10
 on:
   push:
     branches:
@@ -32,13 +32,15 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+      - name: Free space
         # Free space as indicated here : https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
         run: |
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+      - name: Install dependencies
+        run: |
           python -m pip install --upgrade pip
           pip install wheel
           python setup.py sdist bdist_wheel
@@ -78,6 +80,13 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Free space
+        # Free space as indicated here : https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/vision_wheel.yaml
+++ b/.github/workflows/vision_wheel.yaml
@@ -1,4 +1,4 @@
-name: Wheel setup - VISION
+name: Wheel setup - VISION < 3.10
 on:
   push:
     branches:


### PR DESCRIPTION
One of the job (wheel NLP < 3.10) seems to fail because of an out of space error. We follow what's indicated here https://github.com/actions/runner-images/issues/2840#issuecomment-790492173 to solve the problem